### PR TITLE
fixed small bug when parsing difference

### DIFF
--- a/api/states.ts
+++ b/api/states.ts
@@ -17,14 +17,14 @@ export default async (req: NowRequest, res: NowResponse) => {
             let count = $(element).find("td").get(1);
             let difference = $(element).find("td").get(2);
             let deaths = $(element).find("td").get(4);
-            
+
             let state = new State();
             state.name = $(name).text();
             state.count = parseNumber($(count).text());
-            state.difference = parseInt($(difference).text());
+            state.difference = parseNumber($(difference).text());
             state.deaths = parseNumber($(deaths).text());
             state.code = getAbbreviation(state.name);
-            
+
             states.push(state);
         }
     });
@@ -35,7 +35,10 @@ function parseNumber(text: string) {
     if (text == "") {
         return 0;
     }
+
     text = text.replace(".", "");
+    text = text.replace("*", "");
+
     return parseInt(text);
 }
 


### PR DESCRIPTION
Hey everyone, thank you for providing this API :) I fixed a small bug, maybe this is helpful :)

Previous implementation used parseInt() to parse day-to-day difference --> example: "+1.731" was parsed into 1