### PR TITLE
add district type to distinguish between 'Landkreis' and 'Kreisfreie Stadt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You receive a PNG image:
   "districts": [
     {
       "name": "Flensburg",
+      "type": "SK",
       "count": 182,
       "deaths": 3,
       "weekIncidence": 34.3817931768777,
@@ -80,6 +81,7 @@ You receive a PNG image:
     },
     {
       "name": "Kiel",
+      "type": "SK",
       "count": 582,
       "deaths": 12,
       "weekIncidence": 27.5533440845401,
@@ -89,6 +91,7 @@ You receive a PNG image:
     ...
     {
       "name": "Berlin Friedrichshain-Kreuzberg",
+      "type": "SK",
       "count": 2622,
       "deaths": 11,
       "weekIncidence": 172.304376034801,
@@ -97,6 +100,7 @@ You receive a PNG image:
     },
     {
       "name": "Berlin Tempelhof-Schöneberg",
+      "type": "SK",
       "count": 2760,
       "deaths": 28,
       "weekIncidence": 164.729702842831,

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You receive a PNG image:
   "districts": [
     {
       "name": "Flensburg",
-      "type": "SK",
+      "county": "SK Flensburg",
       "count": 182,
       "deaths": 3,
       "weekIncidence": 34.3817931768777,
@@ -81,7 +81,7 @@ You receive a PNG image:
     },
     {
       "name": "Kiel",
-      "type": "SK",
+      "county": "SK Flensburg",
       "count": 582,
       "deaths": 12,
       "weekIncidence": 27.5533440845401,
@@ -91,7 +91,7 @@ You receive a PNG image:
     ...
     {
       "name": "Berlin Friedrichshain-Kreuzberg",
-      "type": "SK",
+      "county": "SK Berlin Friedrichshain-Kreuzberg",
       "count": 2622,
       "deaths": 11,
       "weekIncidence": 172.304376034801,
@@ -100,7 +100,7 @@ You receive a PNG image:
     },
     {
       "name": "Berlin Tempelhof-Schöneberg",
-      "type": "SK",
+      "county": "SK Berlin Tempelhof-Schöneberg",
       "count": 2760,
       "deaths": 28,
       "weekIncidence": 164.729702842831,

--- a/api/districts.ts
+++ b/api/districts.ts
@@ -9,6 +9,7 @@ interface APIData {
 interface Feature {
     attributes: {
         GEN: string,
+        county: string,
         cases: number,
         deaths: number,
         cases_per_100k: number,
@@ -23,13 +24,14 @@ export default async (req: NowRequest, res: NowResponse) => {
     res.setHeader('Cache-Control', 's-maxage=3600');
 
     let districts = [];
-    
-    const repsonse = await axios.get("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_Landkreisdaten/FeatureServer/0/query?where=1%3D1&outFields=GEN,cases,deaths,cases_per_100k,cases_per_population,last_update,cases7_per_100k&outSR=4326&f=json");
-    const apidata: APIData = repsonse.data;
+
+    const response = await axios.get("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_Landkreisdaten/FeatureServer/0/query?where=1%3D1&outFields=GEN,county,cases,deaths,cases_per_100k,cases_per_population,last_update,cases7_per_100k&outSR=4326&f=json");
+    const apidata: APIData = response.data;
 
     for (const feature of apidata.features) {
         let district = new District();
         district.name = feature.attributes.GEN;
+        district.type = feature.attributes.county.substring(0,2);
         district.count = feature.attributes.cases;
         district.deaths = feature.attributes.deaths;
         district.weekIncidence = feature.attributes.cases7_per_100k;

--- a/api/districts.ts
+++ b/api/districts.ts
@@ -31,7 +31,7 @@ export default async (req: NowRequest, res: NowResponse) => {
     for (const feature of apidata.features) {
         let district = new District();
         district.name = feature.attributes.GEN;
-        district.type = feature.attributes.county.substring(0,2);
+        district.county = feature.attributes.county;
         district.count = feature.attributes.cases;
         district.deaths = feature.attributes.deaths;
         district.weekIncidence = feature.attributes.cases7_per_100k;

--- a/models.ts
+++ b/models.ts
@@ -14,6 +14,7 @@ export class State {
 export class District {
 
     public name: string;
+    public type: string;
     public count: number;
     public deaths: number;
     public weekIncidence: number;

--- a/models.ts
+++ b/models.ts
@@ -14,7 +14,7 @@ export class State {
 export class District {
 
     public name: string;
-    public type: string;
+    public county: string;
     public count: number;
     public deaths: number;
     public weekIncidence: number;


### PR DESCRIPTION
Added district type field to distinguish between 'Landkreis' and 'Kreisfreie Stadt'

Some districts seem to appear twice in the output, e.g. München, which exists both as "Landkreis München" (LK) and "Kreisfreie Stadt München" or "Stadtkreis" (SK).