### PR TITLE
Change Dockerfile to make it compatible to arm64, arm32v7 Architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,44 @@
 FROM node:12
 
+# common build paths and flags
+ENV DEST /opt
+ENV PKG_CONFIG_PATH ${PKG_CONFIG_PATH}:${DEST}/lib/pkgconfig
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DEST}/lib
+ENV PATH ${PATH}:${DEST}/bin
+ENV CPPFLAGS -I${DEST}/include
+ENV LDFLAGS -L${DEST}/lib
+ENV CFLAGS -O3
+ENV CXXFLAGS -O3
+
+# build dependencies, libvips and cleanup
+WORKDIR /tmp
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        pkg-config \
+        gtk-doc-tools \
+        glib2.0-dev \
+        curl \
+        gettext \
+        nasm \
+        zlib1g-dev \
+        libjpeg-dev \
+        libpng-dev \
+        libtiff5-dev \
+        libexpat1-dev \
+        libgif-dev \
+        libgsf-1-dev \
+        && curl -sOL https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz \
+        && tar zxf vips-8.10.5.tar.gz \
+        && cd vips-8.10.5 \
+        && ./configure --prefix=${DEST} \
+        && make \
+        && make install \
+        && ldconfig \
+        && apt-get autoremove --purge -y build-essential curl gettext nasm gtk-doc-tools\
+        && apt-get -y clean \
+        && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /tmp/*
+
 # Create app directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Signed-off-by: Peter Markewitz <peter@markewitz.org>
This change make it possible to build the Docker Image on Linux/AMD64, Linux/ARM64 and Linux/ARM32V7 Architectures.
Maybe also Linux/ARM32V6 is possible (not tested yet). But is there anywhere out who wants to run a Dockercontainer on ARM32V6?
by the Way the resulting image for AMD64 ist smaler than bevor!
this will solve Issue #67 
All working well. I am very proud of myself that I managed to do this :-)
![rki-covid-api](https://user-images.githubusercontent.com/6493772/105560065-17cced80-5d13-11eb-90ce-917382cb9f08.png)
