### PR TITLE
Add libimagequant and switch to node:12-alpine3.12

### DIFF
--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -33,7 +33,7 @@ export async function DistrictsMapResponse() {
         stringify(mapData)
     );    
 
-    return sharp(svgBuffer).png({ quality: 1 }).toBuffer();
+    return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
 }
 
 export async function StatesMapResponse() {
@@ -63,7 +63,7 @@ export async function StatesMapResponse() {
         stringify(mapData)
     );    
 
-    return sharp(svgBuffer).png({ quality: 1 }).toBuffer();
+    return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
 }
 
 export function IncidenceColorsResponse() {


### PR DESCRIPTION
This patch results in ~ 10 - 12 % smaller Docker images!
The old Images are missing libary libimagequant witch is needed to allow sharp the use of the quality option as used in src/responses/map.ts

sharp(svgBuffer).png({ quality: 1 }).toBuffer()

therefor we have to switch to baseimage node:12-alpine3.12 because node:12-alpine uses Alpine Linux 3.11 witch has no libimagequant in the repository!

The old images ignore this option!
By the way, why do you set this option quality: to "1"? (default is 100!)

New imagesizes:

![2021-02-04 11_24_59-Window](https://user-images.githubusercontent.com/6493772/107112413-c581e580-6857-11eb-86b2-1b7d1fe668b3.png)

stay save and healthy
Peter