### PR TITLE
Add files for Autobuild on Dockerhub

### DIFF
--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,0 +1,55 @@
+FROM arm32v6/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-arm-static /usr/bin/
+
+# common build flags
+ENV CFLAGS=-O3
+ENV CXXFLAGS=-O3
+
+WORKDIR /tmp
+
+# build dependencies, compile vips-8.10.5 and cleanup.
+RUN wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
+     libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
+ && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && cd vips-8.10.5 \
+ && ./configure --prefix=/usr \
+                --disable-static \
+                --disable-dependency-tracking \
+                --enable-silent-rules \
+ && make -s install-strip \
+ && cd .. \
+ && rm -rf vips-8.10.5 /var/cache/apk/* \
+ && apk del .vips-deps
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+# Inside "npm install" there are some build tools needed
+# Install the tools, execute "npm install" and remove the tolls afterwards
+RUN apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && npm install \
+ && apk del .vips-deps
+# If you are building your code for production
+# RUN npm ci --only=production
+
+RUN npm install pm2 -g
+
+# Bundle app source
+COPY . .
+
+RUN npm run build
+
+EXPOSE 8080
+CMD ["pm2-runtime", "dist/server.js", "-i", "-1"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,55 @@
+FROM arm32v7/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-arm-static /usr/bin/
+
+# common build flags
+ENV CFLAGS=-O3
+ENV CXXFLAGS=-O3
+
+WORKDIR /tmp
+
+# build dependencies, compile vips-8.10.5 and cleanup.
+RUN wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
+     libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
+ && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && cd vips-8.10.5 \
+ && ./configure --prefix=/usr \
+                --disable-static \
+                --disable-dependency-tracking \
+                --enable-silent-rules \
+ && make -s install-strip \
+ && cd .. \
+ && rm -rf vips-8.10.5 /var/cache/apk/* \
+ && apk del .vips-deps
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+# Inside "npm install" there are some build tools needed
+# Install the tools, execute "npm install" and remove the tolls afterwards
+RUN apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && npm install \
+ && apk del .vips-deps
+# If you are building your code for production
+# RUN npm ci --only=production
+
+RUN npm install pm2 -g
+
+# Bundle app source
+COPY . .
+
+RUN npm run build
+
+EXPOSE 8080
+CMD ["pm2-runtime", "dist/server.js", "-i", "-1"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,55 @@
+FROM arm64v8/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-aarch64-static /usr/bin/
+
+# common build flags
+ENV CFLAGS=-O3
+ENV CXXFLAGS=-O3
+
+WORKDIR /tmp
+
+# build dependencies, compile vips-8.10.5 and cleanup.
+RUN wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
+     libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
+ && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && cd vips-8.10.5 \
+ && ./configure --prefix=/usr \
+                --disable-static \
+                --disable-dependency-tracking \
+                --enable-silent-rules \
+ && make -s install-strip \
+ && cd .. \
+ && rm -rf vips-8.10.5 /var/cache/apk/* \
+ && apk del .vips-deps
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+# Inside "npm install" there are some build tools needed
+# Install the tools, execute "npm install" and remove the tolls afterwards
+RUN apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
+     libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
+     poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
+ && npm install \
+ && apk del .vips-deps
+# If you are building your code for production
+# RUN npm ci --only=production
+
+RUN npm install pm2 -g
+
+# Bundle app source
+COPY . .
+
+RUN npm run build
+
+EXPOSE 8080
+CMD ["pm2-runtime", "dist/server.js", "-i", "-1"]

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Get architecture from Dockerfile.arch filename
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+# For amd64 filename is Dockerfile
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Download not required for current arch'; exit 0; }
+
+case ${BUILD_ARCH} in
+    amd64   ) QEMU_ARCH="x86_64" ;;
+    arm32v6 ) QEMU_ARCH="arm" ;;
+    arm32v7 ) QEMU_ARCH="arm" ;;
+    arm64v8 ) QEMU_ARCH="aarch64" ;
+ esac
+
+QEMU_USER_STATIC_DOWNLOAD_URL="https://github.com/multiarch/qemu-user-static/releases/download"
+QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+    | grep 'name.*v[0-9]' \
+    | head -n 1 \
+    | cut -d '"' -f 4)
+
+curl -SL "${QEMU_USER_STATIC_DOWNLOAD_URL}/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz" \
+    | tar xzv

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Use docker cli v20.10.3 to use experimental manifest feature
+curl -SL "https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz" | tar xzv docker/docker --transform='s/.*/docker-cli/'
+mkdir ~/.docker
+# Add auths and experimental to docker-cli config
+echo '{"auths": '$DOCKERCFG',"experimental":"enabled"}' > ~/.docker/config.json
+# Check if all arch images are in dockerhub
+VIRTUAL_IMAGE=$(echo "${IMAGE_NAME}" | rev | cut -d- -f2- | rev )
+
+AMD64_IMAGE="$VIRTUAL_IMAGE-amd64"
+ARM64_IMAGE="$VIRTUAL_IMAGE-arm64v8"
+ARMV7_IMAGE="$VIRTUAL_IMAGE-arm32v7"
+ARMV6_IMAGE="$VIRTUAL_IMAGE-arm32v6"
+
+echo "checking if ${AMD64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${AMD64_IMAGE}; then AMD64_IMAGE='' ; fi
+echo "checking if ${ARMV6_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARMV6_IMAGE}; then ARMV6_IMAGE='' ; fi
+echo "checking if ${ARMV7_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARMV7_IMAGE}; then ARMV7_IMAGE='' ; fi
+echo "checking if ${ARM64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARM64_IMAGE}; then ARM64_IMAGE='' ; fi
+
+echo "Creating multiarch manifest"
+./docker-cli manifest create $VIRTUAL_IMAGE $AMD64_IMAGE $ARMV6_IMAGE $ARMV7_IMAGE $ARM64_IMAGE
+if [ -n "${ARMV6_IMAGE}" ]; then
+  ./docker-cli manifest annotate $VIRTUAL_IMAGE $ARMV6_IMAGE --os linux --arch arm --variant v6
+fi
+if [ -n "${ARMV7_IMAGE}" ]; then
+  ./docker-cli manifest annotate $VIRTUAL_IMAGE $ARMV7_IMAGE --os linux --arch arm --variant v7
+fi
+if [ -n "${ARM64_IMAGE}" ]; then
+./docker-cli manifest annotate $VIRTUAL_IMAGE $ARM64_IMAGE --os linux --arch arm64 --variant v8
+fi
+./docker-cli manifest push $VIRTUAL_IMAGE
+
+rm -r docker-cli ~/.docker

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Registration not required for current arch'; exit 0; }
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
Add files to make it possible to autobuild images on docker hub for the following architectures (multibuild):

1. Linux/amd64
2. Linux/arm/v6 (e.g. Raspberry Pi 1)
3. Linux/arm/v7 (e.g. Raspberry Pi 2-4 32bit OS)
4. Linux/arm64/v8 (e.g. Raspberry 3-4 64 bit OS)

with the following docker hub build settings:

![Autobuild_settings](https://user-images.githubusercontent.com/6493772/107914568-fe5e4080-6f62-11eb-9779-73989bed1e36.png)

all Images are accessible under one tag

![Result](https://user-images.githubusercontent.com/6493772/107914705-4d0bda80-6f63-11eb-9f7d-dcceb1aa1cda.png)
