### PR TITLE
Add Endpoint /testing/history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:12-alpine3.12
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
+ARG VIPS_VERSION=8.10.6
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -21,19 +22,19 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
      libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
- && wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && wget -O- https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz | tar xzC /tmp \
  && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
      libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
      poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
  && ODIR=$(pwd) \
- && cd /tmp/vips-8.10.5 \
+ && cd /tmp/vips-${VIPS_VERSION} \
  && ./configure --prefix=/usr \
                 --disable-static \
                 --disable-dependency-tracking \
                 --enable-silent-rules \
  && make -s install-strip \
  && cd $ODIR \
- && rm -rf /tmp/vips-8.10.5 /var/cache/apk/* \
+ && rm -rf /tmp/vips-${VIPS_VERSION} /var/cache/apk/* \
  && npm install \
  && apk del .vips-deps
 # If you are building your code for production

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -6,7 +6,7 @@ COPY qemu-arm-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
-ARG VIPS_VERSION=8.10.5
+ARG VIPS_VERSION=8.10.6
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -6,6 +6,7 @@ COPY qemu-arm-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
+ARG VIPS_VERSION=8.10.5
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -24,19 +25,19 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
      libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
- && wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && wget -O- https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz | tar xzC /tmp \
  && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
      libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
      poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
  && ODIR=$(pwd) \
- && cd /tmp/vips-8.10.5 \
+ && cd /tmp/vips-${VIPS_VERSION} \
  && ./configure --prefix=/usr \
                 --disable-static \
                 --disable-dependency-tracking \
                 --enable-silent-rules \
  && make -s install-strip \
  && cd $ODIR \
- && rm -rf /tmp/vips-8.10.5 /var/cache/apk/* \
+ && rm -rf /tmp/vips-${VIPS_VERSION} /var/cache/apk/* \
  && npm install \
  && apk del .vips-deps
 # If you are building your code for production

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,4 +1,7 @@
-FROM node:12-alpine3.12
+FROM arm32v6/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-arm-static /usr/bin/
 
 # common build flags
 ENV CFLAGS=-O3

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -6,7 +6,7 @@ COPY qemu-arm-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
-ARG VIPS_VERSION=8.10.5
+ARG VIPS_VERSION=8.10.6
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -6,6 +6,7 @@ COPY qemu-arm-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
+ARG VIPS_VERSION=8.10.5
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -24,19 +25,19 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
      libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
- && wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && wget -O- https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz | tar xzC /tmp \
  && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
      libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
      poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
  && ODIR=$(pwd) \
- && cd /tmp/vips-8.10.5 \
+ && cd /tmp/vips-${VIPS_VERSION} \
  && ./configure --prefix=/usr \
                 --disable-static \
                 --disable-dependency-tracking \
                 --enable-silent-rules \
  && make -s install-strip \
  && cd $ODIR \
- && rm -rf /tmp/vips-8.10.5 /var/cache/apk/* \
+ && rm -rf /tmp/vips-${VIPS_VERSION} /var/cache/apk/* \
  && npm install \
  && apk del .vips-deps
 # If you are building your code for production

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,7 @@
-FROM node:12-alpine3.12
+FROM arm32v7/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-arm-static /usr/bin/
 
 # common build flags
 ENV CFLAGS=-O3

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,7 @@
-FROM node:12-alpine3.12
+FROM arm64v8/node:12-alpine3.12
+
+# Add QEMU
+COPY qemu-aarch64-static /usr/bin/
 
 # common build flags
 ENV CFLAGS=-O3

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ COPY qemu-aarch64-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
+ARG VIPS_VERSION=8.10.5
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -24,19 +25,19 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache zlib libxml2 glib gobject-introspection libjpeg-turbo libexif lcms2 fftw giflib libpng \
      libwebp orc tiff poppler-glib librsvg libgsf openexr libheif libimagequant pango \
- && wget -O- https://github.com/libvips/libvips/releases/download/v8.10.5/vips-8.10.5.tar.gz | tar xzC /tmp \
+ && wget -O- https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz | tar xzC /tmp \
  && apk add --no-cache --virtual .vips-deps build-base binutils zlib-dev libxml2-dev glib-dev gobject-introspection-dev \
      libjpeg-turbo-dev libexif-dev lcms2-dev fftw-dev giflib-dev libpng-dev libwebp-dev orc-dev tiff-dev \
      poppler-dev librsvg-dev libgsf-dev openexr-dev libheif-dev libimagequant-dev pango-dev py-gobject3-dev \
  && ODIR=$(pwd) \
- && cd /tmp/vips-8.10.5 \
+ && cd /tmp/vips-${VIPS_VERSION} \
  && ./configure --prefix=/usr \
                 --disable-static \
                 --disable-dependency-tracking \
                 --enable-silent-rules \
  && make -s install-strip \
  && cd $ODIR \
- && rm -rf /tmp/vips-8.10.5 /var/cache/apk/* \
+ && rm -rf /tmp/vips-${VIPS_VERSION} /var/cache/apk/* \
  && npm install \
  && apk del .vips-deps
 # If you are building your code for production

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -6,7 +6,7 @@ COPY qemu-aarch64-static /usr/bin/
 # common build flags
 ENV CFLAGS=-O3
 ENV CXXFLAGS=-O3
-ARG VIPS_VERSION=8.10.5
+ARG VIPS_VERSION=8.10.6
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you use this API, please consider supporting me:
 - data per state and district
 - time series for every state and district
 - maps for states and districts
-- Count of the weekly carried out PCR-Tests, Count of positiv tests and positiv quotes
+- Number of performed PCR-test, number of positive tests and positivity rate
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A JSON Rest API to query all relevant corona data for Germany based on the figures of the Robert Koch-Institut.
 
-cases 🤧 - deaths ☠️ - recovered 🟢 - **R value** 📈 - week incidence 📅 - **time series** 🗓 - states - districts - **vaccinations** 💉 - **maps** 🗺
+cases 🤧 - deaths ☠️ - recovered 🟢 - **R value** 📈 - week incidence 📅 - **time series** 🗓 - states - districts - **vaccinations** 💉 - **maps** 🗺 -Testing
 
 [https://api.corona-zahlen.org](https://api.corona-zahlen.org)
 
@@ -22,6 +22,7 @@ If you use this API, please consider supporting me:
 - Werte für jedes Bundesland und jeden Landkreis
 - historische Daten für Deutschland, jedes Bundesland and jeden Landkreis
 - Karten mit Bundesländern und Landkreisen
+- Anzahl der wöchentlich durchgeführen PCR-Tests, Anzahl der positiven Tests sowie der Positiv Quote
 
 ## 🇺🇸 Overview
 
@@ -33,6 +34,7 @@ If you use this API, please consider supporting me:
 - data per state and district
 - time series for every state and district
 - maps for states and districts
+- Count of the weekly carried out PCR-Tests, Count of positiv tests and positiv quotes
 
 ## Endpoints
 
@@ -41,6 +43,7 @@ If you use this API, please consider supporting me:
 - [Districts](https://api.corona-zahlen.org/docs/endpoints/districts.html)
 - [Vaccinations](https://api.corona-zahlen.org/docs/endpoints/vaccinations.html)
 - [Maps](https://api.corona-zahlen.org/docs/endpoints/maps.html)
+- [Testing](https://api.corona-zahlen.org/docs/endpoints/testing.html) 
 
 ## Data sources
 
@@ -63,6 +66,10 @@ https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Impfquotenmon
 **R value**
 
 https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Projekte_RKI/Nowcasting_Zahlen.xlsx?__blob=publicationFile
+
+**Testing data**
+
+https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile
 
 ## Host it yourself
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,19 +19,21 @@ module.exports = {
               children: [{
                   title: 'Germany 🇩🇪',
                   path: '/endpoints/germany'
-              },
-              {
-                title: 'States',
-                path: '/endpoints/states'
+              },{
+                  title: 'States',
+                  path: '/endpoints/states'
               },{
                   title: 'Districts',
                   path: '/endpoints/districts'
               },{
-                title: 'Vaccinations 💉',
-                path: '/endpoints/vaccinations'
+                  title: 'Vaccinations 💉',
+                  path: '/endpoints/vaccinations'
               },{
-                title: 'Maps 🗺',
-                path: '/endpoints/maps'
+                  title: 'Maps 🗺',
+                  path: '/endpoints/maps'
+              },{
+                  title: 'Testing',
+                  path: '/endpoints/testing'
               }]
             }
         ],

--- a/docs/endpoints/testing.md
+++ b/docs/endpoints/testing.md
@@ -11,60 +11,60 @@
 
 `calendarWeek` CalendarWeek
 
-`countTesting` Number PCR-tests executed.
+`performedTests` Number PCR-tests executed.
 
-`positiveTesting` Number PCR-tests witch are COVID-19 positiv
+`positiveTests` Number of positive PCR-tests
 
-`positiveQuote` Ouote of COVID-19 positive tests
+`positivityRate` The rate of positive PCR-tests
 
-`countLaboratories` Number Laboratories witch transmitted Data to RKI
+`laboratoryCount` Number of laboratories which transmitted data to the RKI
 
 ```json
 {
     "data":{
         "history":[
             {
-                "calendarWeek":"until CW10, 2020",
-                "countTesting":69184,
-                "positiveTesting":1722,
-                "positiveQuote":null,
-                "countLaboratories":null
+                "calendarWeek":     "until CW10, 2020",
+                "performedTests":   69184,
+                "positiveTests":    1722,
+                "positivityRate":   null,
+                "laboratoryCount":  null,
             },
             {
-                "calendarWeek":"11/2020",
-                "countTesting":128008,
-                "positiveTesting":7470,
-                "positiveQuote":0.05835572776701456,
-                "countLaboratories":118
+                "calendarWeek":     "11/2020",
+                "performedTests":   128008,
+                "positiveTests":    7470,
+                "positivityRate":   0.05835572776701456,
+                "laboratoryCount":  118
             },
             {
-                "calendarWeek":"12/2020",
-                "countTesting":374534,
-                "positiveTesting":25886,
-                "positiveQuote":0.06911522051402542,
-                "countLaboratories":154
+                "calendarWeek":     "12/2020",
+                "performedTests":   374534,
+                "positiveTests":    25886,
+                "positivityRate":   0.06911522051402542,
+                "laboratoryCount":  154
             },
             // ...
             {
-                "calendarWeek":"12/2021",
-                "countTesting":1415220,
-                "positiveTesting":131857,
-                "positiveQuote":0.09317067311089441,
-                "countLaboratories":206
+                "calendarWeek":     "12/2021",
+                "performedTests":   1415220,
+                "positiveTests":    131857,
+                "positivityRate":   0.09317067311089441,
+                "laboratoryCount":  206
             },
             {
-                "calendarWeek":"13/2021",
-                "countTesting":1167760,
-                "positiveTesting":128266,
-                "positiveQuote":0.10983935055148318,
-                "countLaboratories":204
+                "calendarWeek":     "13/2021",
+                "performedTests":   1167760,
+                "positiveTests":    128266,
+                "positivityRate":   0.10983935055148318,
+                "laboratoryCount":  204
             },
             {
-                "calendarWeek":"14/2021",
-                "countTesting":1152511,
-                "positiveTesting":138738,
-                "positiveQuote":0.12037889443137637,
-                "countLaboratories":201
+                "calendarWeek":     "14/2021",
+                "performedTests":   1152511,
+                "positiveTests":    138738,
+                "positivityRate":   0.12037889443137637,
+                "laboratoryCount":  201
             }
         ]
     },

--- a/docs/endpoints/testing.md
+++ b/docs/endpoints/testing.md
@@ -5,66 +5,66 @@
 ### Request
 
 `GET https://api.corona-zahlen.org/testing/history`
-[Open](/testing)
+[Open](/testing/history)
 
 ### Response
 
-`CalendarWeek` CalendarWeek
+`calendarWeek` CalendarWeek
 
-`CountTesting` Number PCR-tests executed.
+`countTesting` Number PCR-tests executed.
 
-`PositiveTesting` Number PCR-tests witch are COVID-19 positiv
+`positiveTesting` Number PCR-tests witch are COVID-19 positiv
 
-`PositivQuote` Ouote of COVID-19 positiv tests
+`positiveQuote` Ouote of COVID-19 positive tests
 
-`CountLaboratories` Number Laboratories witch transmitted Data to RKI
+`countLaboratories` Number Laboratories witch transmitted Data to RKI
 
 ```json
 {
     "data":{
         "history":[
             {
-                "CalendarWeek":"until CW10, 2020",
-                "CountTesting":69184,
-                "PositivTesting":1722,
-                "PositivQuote":null,
-                "CountLaboratories":null
+                "calendarWeek":"until CW10, 2020",
+                "countTesting":69184,
+                "positiveTesting":1722,
+                "positiveQuote":null,
+                "countLaboratories":null
             },
             {
-                "CalendarWeek":"11/2020",
-                "CountTesting":128008,
-                "PositivTesting":7470,
-                "PositivQuote":0.05835572776701456,
-                "CountLaboratories":118
+                "calendarWeek":"11/2020",
+                "countTesting":128008,
+                "positiveTesting":7470,
+                "positiveQuote":0.05835572776701456,
+                "countLaboratories":118
             },
             {
-                "CalendarWeek":"12/2020",
-                "CountTesting":374534,
-                "PositivTesting":25886,
-                "PositivQuote":0.06911522051402542,
-                "CountLaboratories":154
+                "calendarWeek":"12/2020",
+                "countTesting":374534,
+                "positiveTesting":25886,
+                "positiveQuote":0.06911522051402542,
+                "countLaboratories":154
             },
             // ...
             {
-                "CalendarWeek":"12/2021",
-                "CountTesting":1415220,
-                "PositivTesting":131857,
-                "PositivQuote":0.09317067311089441,
-                "CountLaboratories":206
+                "calendarWeek":"12/2021",
+                "countTesting":1415220,
+                "positiveTesting":131857,
+                "positiveQuote":0.09317067311089441,
+                "countLaboratories":206
             },
             {
-                "CalendarWeek":"13/2021",
-                "CountTesting":1167760,
-                "PositivTesting":128266,
-                "PositivQuote":0.10983935055148318,
-                "CountLaboratories":204
+                "calendarWeek":"13/2021",
+                "countTesting":1167760,
+                "positiveTesting":128266,
+                "positiveQuote":0.10983935055148318,
+                "countLaboratories":204
             },
             {
-                "CalendarWeek":"14/2021",
-                "CountTesting":1152511,
-                "PositivTesting":138738,
-                "PositivQuote":0.12037889443137637,
-                "CountLaboratories":201
+                "calendarWeek":"14/2021",
+                "countTesting":1152511,
+                "positiveTesting":138738,
+                "positiveQuote":0.12037889443137637,
+                "countLaboratories":201
             }
         ]
     },

--- a/docs/endpoints/testing.md
+++ b/docs/endpoints/testing.md
@@ -1,0 +1,80 @@
+# Testing History
+
+## `/testing/history`
+
+### Request
+
+`GET https://api.corona-zahlen.org/testing/history`
+[Open](/testing)
+
+### Response
+
+`CalendarWeek` CalendarWeek
+
+`CountTesting` Number PCR-tests executed.
+
+`PositiveTesting` Number PCR-tests witch are COVID-19 positiv
+
+`PositivQuote` Ouote of COVID-19 positiv tests
+
+`CountLaboratories` Number Laboratories witch transmitted Data to RKI
+
+```json
+{
+    "data":{
+        "history":[
+            {
+                "CalendarWeek":"until CW10, 2020",
+                "CountTesting":69184,
+                "PositivTesting":1722,
+                "PositivQuote":null,
+                "CountLaboratories":null
+            },
+            {
+                "CalendarWeek":"11/2020",
+                "CountTesting":128008,
+                "PositivTesting":7470,
+                "PositivQuote":0.05835572776701456,
+                "CountLaboratories":118
+            },
+            {
+                "CalendarWeek":"12/2020",
+                "CountTesting":374534,
+                "PositivTesting":25886,
+                "PositivQuote":0.06911522051402542,
+                "CountLaboratories":154
+            },
+            // ...
+            {
+                "CalendarWeek":"12/2021",
+                "CountTesting":1415220,
+                "PositivTesting":131857,
+                "PositivQuote":0.09317067311089441,
+                "CountLaboratories":206
+            },
+            {
+                "CalendarWeek":"13/2021",
+                "CountTesting":1167760,
+                "PositivTesting":128266,
+                "PositivQuote":0.10983935055148318,
+                "CountLaboratories":204
+            },
+            {
+                "CalendarWeek":"14/2021",
+                "CountTesting":1152511,
+                "PositivTesting":138738,
+                "PositivQuote":0.12037889443137637,
+                "CountLaboratories":201
+            }
+        ]
+    },
+    "meta":
+        {
+            "source":"Robert Koch-Institut",
+            "contact":"Marlon Lueckert (m.lueckert@me.com)",
+            "info":"https://github.com/marlon360/rki-covid-api",
+            "lastUpdate":"2021-04-14T14:54:08.000Z",
+            "lastCheckedForUpdate":"2021-04-14T20:59:21.345Z"
+        }
+}
+```

--- a/docs/endpoints/testing.md
+++ b/docs/endpoints/testing.md
@@ -5,66 +5,66 @@
 ### Request
 
 `GET https://api.corona-zahlen.org/testing/history`
-[Open](/testing/history)
+[Open](/testing)
 
 ### Response
 
-`calendarWeek` CalendarWeek
+`CalendarWeek` CalendarWeek
 
-`countTesting` Number PCR-tests executed.
+`CountTesting` Number PCR-tests executed.
 
-`positiveTesting` Number PCR-tests witch are COVID-19 positiv
+`PositiveTesting` Number PCR-tests witch are COVID-19 positiv
 
-`positiveQuote` Ouote of COVID-19 positive tests
+`PositivQuote` Ouote of COVID-19 positiv tests
 
-`countLaboratories` Number Laboratories witch transmitted Data to RKI
+`CountLaboratories` Number Laboratories witch transmitted Data to RKI
 
 ```json
 {
     "data":{
         "history":[
             {
-                "calendarWeek":"until CW10, 2020",
-                "countTesting":69184,
-                "positiveTesting":1722,
-                "positiveQuote":null,
-                "countLaboratories":null
+                "CalendarWeek":"until CW10, 2020",
+                "CountTesting":69184,
+                "PositivTesting":1722,
+                "PositivQuote":null,
+                "CountLaboratories":null
             },
             {
-                "calendarWeek":"11/2020",
-                "countTesting":128008,
-                "positiveTesting":7470,
-                "positiveQuote":0.05835572776701456,
-                "countLaboratories":118
+                "CalendarWeek":"11/2020",
+                "CountTesting":128008,
+                "PositivTesting":7470,
+                "PositivQuote":0.05835572776701456,
+                "CountLaboratories":118
             },
             {
-                "calendarWeek":"12/2020",
-                "countTesting":374534,
-                "positiveTesting":25886,
-                "positiveQuote":0.06911522051402542,
-                "countLaboratories":154
+                "CalendarWeek":"12/2020",
+                "CountTesting":374534,
+                "PositivTesting":25886,
+                "PositivQuote":0.06911522051402542,
+                "CountLaboratories":154
             },
             // ...
             {
-                "calendarWeek":"12/2021",
-                "countTesting":1415220,
-                "positiveTesting":131857,
-                "positiveQuote":0.09317067311089441,
-                "countLaboratories":206
+                "CalendarWeek":"12/2021",
+                "CountTesting":1415220,
+                "PositivTesting":131857,
+                "PositivQuote":0.09317067311089441,
+                "CountLaboratories":206
             },
             {
-                "calendarWeek":"13/2021",
-                "countTesting":1167760,
-                "positiveTesting":128266,
-                "positiveQuote":0.10983935055148318,
-                "countLaboratories":204
+                "CalendarWeek":"13/2021",
+                "CountTesting":1167760,
+                "PositivTesting":128266,
+                "PositivQuote":0.10983935055148318,
+                "CountLaboratories":204
             },
             {
-                "calendarWeek":"14/2021",
-                "countTesting":1152511,
-                "positiveTesting":138738,
-                "positiveQuote":0.12037889443137637,
-                "countLaboratories":201
+                "CalendarWeek":"14/2021",
+                "CountTesting":1152511,
+                "PositivTesting":138738,
+                "PositivQuote":0.12037889443137637,
+                "CountLaboratories":201
             }
         ]
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,7 @@ If you use this API, please consider supporting me:
 - data per state and district
 - time series for every state and district
 - maps for states and districts
-- Count of the weekly carried out PCR-Tests, Count of positiv tests and positiv quotes
-
+- Number of performed PCR-test, number of positive tests and positivity rate
 ## Endpoints
 
 - [Germany](endpoints/germany.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ If you use this API, please consider supporting me:
 
 **Testing data**
 
-https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile
+[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile)
 
 ## Host it yourself
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ If you use this API, please consider supporting me:
 - time series for every state and district
 - maps for states and districts
 - Number of performed PCR-test, number of positive tests and positivity rate
+
 ## Endpoints
 
 - [Germany](endpoints/germany.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A JSON Rest API to query all relevant corona data for Germany based on the figures of the Robert Koch-Institut.
 
-cases 🤧 - deaths ☠️ - recovered 🟢 - **R value** 📈 - week incidence 📅 - **time series** 🗓 - states - districts - **vaccinations** 💉 - **maps** 🗺
+cases 🤧 - deaths ☠️ - recovered 🟢 - **R value** 📈 - week incidence 📅 - **time series** 🗓 - states - districts - **vaccinations** 💉 - **maps** 🗺 - PCR-tests
 
 [https://api.corona-zahlen.org](https://api.corona-zahlen.org)
 
@@ -22,6 +22,7 @@ If you use this API, please consider supporting me:
 - Werte für jedes Bundesland und jeden Landkreis
 - historische Daten für Deutschland, jedes Bundesland and jeden Landkreis
 - Karten mit Bundesländern und Landkreisen
+- Anzahl der wöchentlich durchgeführen PCR-Tests, Anzahl der positiven Tests sowie der Positiv Quote
 
 ## 🇺🇸 Overview
 
@@ -33,6 +34,7 @@ If you use this API, please consider supporting me:
 - data per state and district
 - time series for every state and district
 - maps for states and districts
+- Count of the weekly carried out PCR-Tests, Count of positiv tests and positiv quotes
 
 ## Endpoints
 
@@ -41,6 +43,7 @@ If you use this API, please consider supporting me:
 - [Districts](endpoints/districts.md)
 - [Vaccinations](endpoints/vaccinations.md)
 - [Maps](endpoints/maps.md)
+- [Testing](endpoints/testing.md) 
 
 ## Data sources
 
@@ -63,6 +66,10 @@ If you use this API, please consider supporting me:
 **R value**
 
 [https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Projekte_RKI/Nowcasting_Zahlen.xlsx?__blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Projekte_RKI/Nowcasting_Zahlen.xlsx?__blob=publicationFile)
+
+**Testing data**
+
+https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile
 
 ## Host it yourself
 

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Get architecture from Dockerfile.arch filename
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+# For amd64 filename is Dockerfile
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Download not required for current arch'; exit 0; }
+
+case ${BUILD_ARCH} in
+    amd64   ) QEMU_ARCH="x86_64" ;;
+    arm32v6 ) QEMU_ARCH="arm" ;;
+    arm32v7 ) QEMU_ARCH="arm" ;;
+    arm64v8 ) QEMU_ARCH="aarch64" ;
+ esac
+
+QEMU_USER_STATIC_DOWNLOAD_URL="https://github.com/multiarch/qemu-user-static/releases/download"
+QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+    | grep 'name.*v[0-9]' \
+    | head -n 1 \
+    | cut -d '"' -f 4)
+
+curl -SL "${QEMU_USER_STATIC_DOWNLOAD_URL}/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz" \
+    | tar xzv

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Use docker cli v20.10.3 to use experimental manifest feature
+curl -SL "https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz" | tar xzv docker/docker --transform='s/.*/docker-cli/'
+mkdir ~/.docker
+# Add auths and experimental to docker-cli config
+echo '{"auths": '$DOCKERCFG',"experimental":"enabled"}' > ~/.docker/config.json
+# Check if all arch images are in dockerhub
+VIRTUAL_IMAGE=$(echo "${IMAGE_NAME}" | rev | cut -d- -f2- | rev )
+
+AMD64_IMAGE="$VIRTUAL_IMAGE-amd64"
+ARM64_IMAGE="$VIRTUAL_IMAGE-arm64v8"
+ARMV7_IMAGE="$VIRTUAL_IMAGE-arm32v7"
+ARMV6_IMAGE="$VIRTUAL_IMAGE-arm32v6"
+
+echo "checking if ${AMD64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${AMD64_IMAGE}; then AMD64_IMAGE='' ; fi
+echo "checking if ${ARMV6_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARMV6_IMAGE}; then ARMV6_IMAGE='' ; fi
+echo "checking if ${ARMV7_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARMV7_IMAGE}; then ARMV7_IMAGE='' ; fi
+echo "checking if ${ARM64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARM64_IMAGE}; then ARM64_IMAGE='' ; fi
+
+echo "Creating multiarch manifest"
+./docker-cli manifest create $VIRTUAL_IMAGE $AMD64_IMAGE $ARMV6_IMAGE $ARMV7_IMAGE $ARM64_IMAGE
+if [ -n "${ARMV6_IMAGE}" ]; then
+  ./docker-cli manifest annotate $VIRTUAL_IMAGE $ARMV6_IMAGE --os linux --arch arm --variant v6
+fi
+if [ -n "${ARMV7_IMAGE}" ]; then
+  ./docker-cli manifest annotate $VIRTUAL_IMAGE $ARMV7_IMAGE --os linux --arch arm --variant v7
+fi
+if [ -n "${ARM64_IMAGE}" ]; then
+./docker-cli manifest annotate $VIRTUAL_IMAGE $ARM64_IMAGE --os linux --arch arm64 --variant v8
+fi
+./docker-cli manifest push $VIRTUAL_IMAGE
+
+rm -r docker-cli ~/.docker

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+[ "${BUILD_ARCH}" == "Dockerfile" ] && \
+    { echo 'qemu-user-static: Registration not required for current arch'; exit 0; }
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/src/data-requests/testing.ts
+++ b/src/data-requests/testing.ts
@@ -4,10 +4,10 @@ import { ResponseData } from "./response-data";
 
 export interface testingHistoryEntry{
     calendarWeek: string,
-    countTesting: number,
-    positiveTesting: number,
-    positiveQuote: number,
-    countLaboratories: number
+    performedTests: number,
+    positiveTests: number,
+    positivityRate: number,
+    laboratoryCount: number
 } 
 
 export async function getTestingHistory(): Promise<ResponseData<testingHistoryEntry[]>> {
@@ -37,21 +37,21 @@ export async function getTestingHistory(): Promise<ResponseData<testingHistoryEn
         if (entry.Kalenderwoche === "Bis einschließlich KW10, 2020") {
             testingHistory.push({
                 calendarWeek: "until CW10, 2020",
-                countTesting: entry['Anzahl Testungen'],
-                positiveTesting: entry['Positiv getestet'],
-                positiveQuote: null,
-                countLaboratories: null
+                performedTests: entry['Anzahl Testungen'],
+                positiveTests: entry['Positiv getestet'],
+                positivityRate: null,
+                laboratoryCount: null
             })
         } else if (entry.Kalenderwoche === "Summe") {
         // do nothing, skip this entry
         }  
         else { 
             testingHistory.push({
-            calendarWeek: entry.Kalenderwoche,
-            countTesting: entry['Anzahl Testungen'],
-            positiveTesting: entry['Positiv getestet'],
-            positiveQuote: entry['Positivenanteil (%)'] / 100,
-            countLaboratories: entry['Anzahl übermittelnder Labore']
+                calendarWeek: entry.Kalenderwoche,
+                performedTests: entry['Anzahl Testungen'],
+                positiveTests: entry['Positiv getestet'],
+                positivityRate: entry['Positivenanteil (%)'] / 100,
+                laboratoryCount: entry['Anzahl übermittelnder Labore']
             })
         }  
     }

--- a/src/data-requests/testing.ts
+++ b/src/data-requests/testing.ts
@@ -3,11 +3,11 @@ import XLSX from 'xlsx';
 import { ResponseData } from "./response-data";
 
 export interface testingHistoryEntry{
-    calendarWeek: string,
-    countTesting: number,
-    positiveTesting: number,
-    positiveQuote: number,
-    countLaboratories: number
+    CalendarWeek: string,
+    CountTesting: number,
+    PositivTesting: number,
+    PositivQuote: number,
+    CountLaboratories: number
 } 
 
 export async function getTestingHistory(): Promise<ResponseData<testingHistoryEntry[]>> {
@@ -36,22 +36,22 @@ export async function getTestingHistory(): Promise<ResponseData<testingHistoryEn
     for (const entry of json) {
         if (entry.Kalenderwoche === "Bis einschließlich KW10, 2020") {
             testingHistory.push({
-                calendarWeek: "until CW10, 2020",
-                countTesting: entry['Anzahl Testungen'],
-                positiveTesting: entry['Positiv getestet'],
-                positiveQuote: null,
-                countLaboratories: null
+                CalendarWeek: "until CW10, 2020",
+                CountTesting: entry['Anzahl Testungen'],
+                PositivTesting: entry['Positiv getestet'],
+                PositivQuote: null,
+                CountLaboratories: null
             })
         } else if (entry.Kalenderwoche === "Summe") {
         // do nothing, skip this entry
         }  
         else { 
             testingHistory.push({
-            calendarWeek: entry.Kalenderwoche,
-            countTesting: entry['Anzahl Testungen'],
-            positiveTesting: entry['Positiv getestet'],
-            positiveQuote: entry['Positivenanteil (%)'] / 100,
-            countLaboratories: entry['Anzahl übermittelnder Labore']
+            CalendarWeek: entry.Kalenderwoche,
+            CountTesting: entry['Anzahl Testungen'],
+            PositivTesting: entry['Positiv getestet'],
+            PositivQuote: entry['Positivenanteil (%)'] / 100,
+            CountLaboratories: entry['Anzahl übermittelnder Labore']
             })
         }  
     }

--- a/src/data-requests/testing.ts
+++ b/src/data-requests/testing.ts
@@ -3,11 +3,11 @@ import XLSX from 'xlsx';
 import { ResponseData } from "./response-data";
 
 export interface testingHistoryEntry{
-    CalendarWeek: string,
-    CountTesting: number,
-    PositivTesting: number,
-    PositivQuote: number,
-    CountLaboratories: number
+    calendarWeek: string,
+    countTesting: number,
+    positiveTesting: number,
+    positiveQuote: number,
+    countLaboratories: number
 } 
 
 export async function getTestingHistory(): Promise<ResponseData<testingHistoryEntry[]>> {
@@ -36,22 +36,22 @@ export async function getTestingHistory(): Promise<ResponseData<testingHistoryEn
     for (const entry of json) {
         if (entry.Kalenderwoche === "Bis einschließlich KW10, 2020") {
             testingHistory.push({
-                CalendarWeek: "until CW10, 2020",
-                CountTesting: entry['Anzahl Testungen'],
-                PositivTesting: entry['Positiv getestet'],
-                PositivQuote: null,
-                CountLaboratories: null
+                calendarWeek: "until CW10, 2020",
+                countTesting: entry['Anzahl Testungen'],
+                positiveTesting: entry['Positiv getestet'],
+                positiveQuote: null,
+                countLaboratories: null
             })
         } else if (entry.Kalenderwoche === "Summe") {
         // do nothing, skip this entry
         }  
         else { 
             testingHistory.push({
-            CalendarWeek: entry.Kalenderwoche,
-            CountTesting: entry['Anzahl Testungen'],
-            PositivTesting: entry['Positiv getestet'],
-            PositivQuote: entry['Positivenanteil (%)'] / 100,
-            CountLaboratories: entry['Anzahl übermittelnder Labore']
+            calendarWeek: entry.Kalenderwoche,
+            countTesting: entry['Anzahl Testungen'],
+            positiveTesting: entry['Positiv getestet'],
+            positiveQuote: entry['Positivenanteil (%)'] / 100,
+            countLaboratories: entry['Anzahl übermittelnder Labore']
             })
         }  
     }

--- a/src/data-requests/testing.ts
+++ b/src/data-requests/testing.ts
@@ -1,0 +1,63 @@
+import axios from "axios";
+import XLSX from 'xlsx';
+import { ResponseData } from "./response-data";
+
+export interface testingHistoryEntry{
+    CalendarWeek: string,
+    CountTesting: number,
+    PositivTesting: number,
+    PositivQuote: number,
+    CountLaboratories: number
+} 
+
+export async function getTestingHistory(): Promise<ResponseData<testingHistoryEntry[]>> {
+
+    const response = await axios.get(`https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile`, {
+        responseType: 'arraybuffer'
+    });
+    const data = response.data;
+    const lastModified = response.headers['last-modified'];
+    const lastUpdate = lastModified != null ? new Date(lastModified) : new Date();
+
+    var workbook = XLSX.read(data, { type: 'buffer' });
+
+    const sheet = workbook.Sheets[workbook.SheetNames[1]];
+
+    const json = XLSX.utils.sheet_to_json<{
+        Kalenderwoche: string,
+        'Anzahl Testungen': number,
+        'Positiv getestet': number,
+        'Positivenanteil (%)': number,
+        'Anzahl übermittelnder Labore': number
+    }>(sheet)
+    
+    const testingHistory: testingHistoryEntry[] = []
+    
+    for (const entry of json) {
+        if (entry.Kalenderwoche === "Bis einschließlich KW10, 2020") {
+            testingHistory.push({
+                CalendarWeek: "until CW10, 2020",
+                CountTesting: entry['Anzahl Testungen'],
+                PositivTesting: entry['Positiv getestet'],
+                PositivQuote: null,
+                CountLaboratories: null
+            })
+        } else if (entry.Kalenderwoche === "Summe") {
+        // do nothing, skip this entry
+        }  
+        else { 
+            testingHistory.push({
+            CalendarWeek: entry.Kalenderwoche,
+            CountTesting: entry['Anzahl Testungen'],
+            PositivTesting: entry['Positiv getestet'],
+            PositivQuote: entry['Positivenanteil (%)'] / 100,
+            CountLaboratories: entry['Anzahl übermittelnder Labore']
+            })
+        }  
+    }
+    return {
+        data: testingHistory,
+        lastUpdate: lastUpdate
+    }
+
+}

--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -33,7 +33,7 @@ export async function DistrictsMapResponse() {
         stringify(mapData)
     );    
 
-    return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
+    return sharp(svgBuffer).png({ quality: 20 }).toBuffer();
 }
 
 export async function StatesMapResponse() {
@@ -63,7 +63,7 @@ export async function StatesMapResponse() {
         stringify(mapData)
     );    
 
-    return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
+    return sharp(svgBuffer).png({ quality: 20 }).toBuffer();
 }
 
 export function IncidenceColorsResponse() {

--- a/src/responses/testing.ts
+++ b/src/responses/testing.ts
@@ -1,0 +1,20 @@
+import { IResponseMeta, ResponseMeta } from './meta'
+import { getTestingHistory, testingHistoryEntry } from '../data-requests/testing'
+
+interface TestingHistoryData extends IResponseMeta {
+    data: {
+        history: testingHistoryEntry[]
+    }
+}
+
+export async function TestingHistoryResponse(): Promise<TestingHistoryData> {
+
+    const TestingData = await getTestingHistory();
+
+    return {
+        data: {
+            history: TestingData.data
+        },
+        meta: new ResponseMeta(TestingData.lastUpdate)
+    }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { StatesCasesHistoryResponse, StatesDeathsHistoryResponse, StatesRecovere
 import { GermanyCasesHistoryResponse, GermanyDeathsHistoryResponse, GermanyRecoveredHistoryResponse, GermanyResponse, GermanyWeekIncidenceHistoryResponse } from './responses/germany';
 import { DistrictsCasesHistoryResponse, DistrictsDeathsHistoryResponse, DistrictsRecoveredHistoryResponse, DistrictsResponse, DistrictsWeekIncidenceHistoryResponse } from './responses/districts'
 import { VaccinationResponse, VaccinationHistoryResponse } from './responses/vaccination'
+import { TestingHistoryResponse} from './responses/testing' 
 import { DistrictsMapResponse, IncidenceColorsResponse, StatesMapResponse } from './responses/map';
 import { RKIError } from './utils';
 
@@ -328,6 +329,11 @@ app.get('/map/states', queuedCache(), cache.route(), async (req, res) => {
 
 app.get('/map/states/legend', queuedCache(), cache.route(), async (req, res) => {
   res.json(IncidenceColorsResponse());
+})
+
+app.get('/testing/history',queuedCache(), cache.route(), async (req, res) => {
+  const response = await TestingHistoryResponse();
+  res.json(response)
 })
 
 app.use(function (error: any, req: Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
add a new endpoint /testing/history witch provides the  number of weekly done PCR-tests, the number of positive test in this week, the positiv tests quote and the number of transmitting laboratories.
Fix #176  