### PR TITLE
remove double entry for link /districts/:district in server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -199,11 +199,6 @@ app.get('/districts', queuedCache(), cache.route(), async (req, res) => {
   res.json(response)
 })
 
-app.get('/districts/:district', queuedCache(), cache.route(), async (req, res) => {
-  const response = await DistrictsResponse(req.params.district);
-  res.json(response)
-})
-
 app.get('/districts/history', async (req, res) => {
   res.redirect('/districts/history/cases')
 })


### PR DESCRIPTION
Remove double entry block for app.get('/districts/:district' in server.ts
1st block
https://github.com/marlon360/rki-covid-api/blob/3aea537f7a767ad3487efef4d81e53b75f1f99ae/src/server.ts#L202-L205

2nd block
https://github.com/marlon360/rki-covid-api/blob/3aea537f7a767ad3487efef4d81e53b75f1f99ae/src/server.ts#L251-L254

will fix #146 
i dont know why, but it fix it!