### PR TITLE
Restricted history for testing and vaccination

### DIFF
--- a/docs/endpoints/testing.md
+++ b/docs/endpoints/testing.md
@@ -77,3 +77,16 @@
   }
 }
 ```
+
+## `/testing/history/:weeks`
+
+### Request
+
+`GET https://api.corona-zahlen.org/testing/history/7`
+[Open](/testing/history/7)
+
+**Parameters**
+
+| Parameter | Description                            |
+| --------- | -------------------------------------- |
+| :weeks    | Number of weeks in the past from today |

--- a/docs/endpoints/vaccinations.md
+++ b/docs/endpoints/vaccinations.md
@@ -209,3 +209,16 @@
   }
 }
 ```
+
+## `/vaccinations/history/:days`
+
+### Request
+
+`GET https://api.corona-zahlen.org/vaccinations/history/7`
+[Open](/vaccinations/history/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |

--- a/src/data-requests/testing.ts
+++ b/src/data-requests/testing.ts
@@ -10,9 +10,9 @@ export interface testingHistoryEntry {
   laboratoryCount: number;
 }
 
-export async function getTestingHistory(): Promise<
-  ResponseData<testingHistoryEntry[]>
-> {
+export async function getTestingHistory(
+  weeks?: number
+): Promise<ResponseData<testingHistoryEntry[]>> {
   const response = await axios.get(
     `https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-gesamt.xlsx?__blob=publicationFile`,
     {
@@ -35,7 +35,7 @@ export async function getTestingHistory(): Promise<
     "Anzahl übermittelnder Labore": number;
   }>(sheet);
 
-  const testingHistory: testingHistoryEntry[] = [];
+  let testingHistory: testingHistoryEntry[] = [];
 
   for (const entry of json) {
     if (entry.Kalenderwoche === "Bis einschließlich KW10, 2020") {
@@ -58,6 +58,11 @@ export async function getTestingHistory(): Promise<
       });
     }
   }
+
+  if (weeks != null) {
+    testingHistory = testingHistory.slice(-weeks);
+  }
+
   return {
     data: testingHistory,
     lastUpdate: lastUpdate,

--- a/src/responses/testing.ts
+++ b/src/responses/testing.ts
@@ -10,8 +10,10 @@ interface TestingHistoryData extends IResponseMeta {
   };
 }
 
-export async function TestingHistoryResponse(): Promise<TestingHistoryData> {
-  const TestingData = await getTestingHistory();
+export async function TestingHistoryResponse(
+  weeks?: number
+): Promise<TestingHistoryData> {
+  const TestingData = await getTestingHistory(weeks);
 
   return {
     data: {

--- a/src/responses/vaccination.ts
+++ b/src/responses/vaccination.ts
@@ -27,8 +27,10 @@ interface VaccinationHistoryData extends IResponseMeta {
   };
 }
 
-export async function VaccinationHistoryResponse(): Promise<VaccinationHistoryData> {
-  const vaccinationData = await getVaccinationHistory();
+export async function VaccinationHistoryResponse(
+  days?: number
+): Promise<VaccinationHistoryData> {
+  const vaccinationData = await getVaccinationHistory(days);
 
   return {
     data: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -606,6 +606,18 @@ app.get(
   }
 );
 
+app.get(
+  "/vaccinations/history/:days",
+  queuedCache(),
+  cache.route(),
+  async (req, res) => {
+    const response = await VaccinationHistoryResponse(
+      parseInt(req.params.days)
+    );
+    res.json(response);
+  }
+);
+
 app.get("/map", async (req, res) => {
   res.redirect("/map/districts");
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -657,6 +657,16 @@ app.get("/testing/history", queuedCache(), cache.route(), async (req, res) => {
   res.json(response);
 });
 
+app.get(
+  "/testing/history/:weeks",
+  queuedCache(),
+  cache.route(),
+  async (req, res) => {
+    const response = await TestingHistoryResponse(parseInt(req.params.weeks));
+    res.json(response);
+  }
+);
+
 app.use(function (error: any, req: Request, res: Response, next: NextFunction) {
   if (error instanceof RKIError) {
     res.json({


### PR DESCRIPTION
this implements two new endpoints:

`/vaccinations/history/:days` and 
`/testing/history/:weeks`