### PR TITLE
Get data by age groups

### DIFF
--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -422,3 +422,34 @@ Returns the number of recovered people in germany for the last `:days` days.
   }
 }
 ```
+
+## `/germany/age-groups`
+
+### Request
+
+`GET https://api.corona-zahlen.org/germany/age-groups`
+[Open](/germany/age-groups)
+
+### Response
+
+```json
+{
+  "data": {
+    "casesMale": 94628,
+    "casesFemale": 185126,
+    "deathsMale": 25492,
+    "deathsFemale": 30763,
+    "casesMalePer100k": 4373.1,
+    "casesFemalePer100k": 5263.4,
+    "deathsMalePer100k": 1178.1,
+    "deathsFemalePer100k": 874.6
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2021-05-04T01:09:15.000Z",
+    "lastCheckedForUpdate": "2021-05-04T20:34:41.427Z"
+  }
+}
+```

--- a/docs/endpoints/states.md
+++ b/docs/endpoints/states.md
@@ -145,6 +145,78 @@ Redirects to `/states/history/cases`
 
 ## `/states/history/recovered/:days`
 
+## `/states/age-groups`
+
+### Request
+
+`GET https://api.corona-zahlen.org/states/age-groups`
+[Open](/states/age-groups)
+
+### Response
+
+```json
+{
+  "data": {
+    "SH": {
+      "A00-A04": {
+        "casesMale": 71,
+        "casesFemale": 72,
+        "deathsMale": 0,
+        "deathsFemale": 1,
+        "casesMalePer100k": 1225.2,
+        "casesFemalePer100k": 1321.6,
+        "deathsMalePer100k": 0,
+        "deathsFemalePer100k": 18.4
+      },
+      "A05-A14": {
+        "casesMale": 202,
+        "casesFemale": 169,
+        "deathsMale": 0,
+        "deathsFemale": 0,
+        "casesMalePer100k": 1663.4,
+        "casesFemalePer100k": 1462.7,
+        "deathsMalePer100k": 0,
+        "deathsFemalePer100k": 0
+      },
+      "A15-A34": {
+        // ...
+      },
+      "A35-A59": {
+        // ...
+      },
+      "A60-A79": {
+        // ...
+      },
+      "A80+": {
+        // ...
+      }
+    },
+    // ...
+    "TH": {
+      "A00-A04": {
+        "casesMale": 1228,
+        "casesFemale": 1191,
+        "deathsMale": 0,
+        "deathsFemale": 0,
+        "casesMalePer100k": 2656.9,
+        "casesFemalePer100k": 2699.5,
+        "deathsMalePer100k": 0,
+        "deathsFemalePer100k": 0
+      },
+      // ...
+    },
+    }
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2021-05-04T01:09:15.000Z",
+    "lastCheckedForUpdate": "2021-05-04T20:42:11.340Z"
+  }
+}
+```
+
 ## `/states/:state/history/cases`
 
 ## `/states/:state/history/cases/:days`
@@ -160,3 +232,60 @@ Redirects to `/states/history/cases`
 ## `/states/:state/history/recovered`
 
 ## `/states/:state/history/recovered/:days`
+
+## `/states/:state/age-groups`
+
+### Request
+
+`GET https://api.corona-zahlen.org/states/HH/age-groups`
+[Open](/states/HH/age-groups)
+
+### Response
+
+```json
+{
+  "data": {
+    "HH": {
+      "A00-A04": {
+        "casesMale": 1095,
+        "casesFemale": 863,
+        "deathsMale": 0,
+        "deathsFemale": 0,
+        "casesMalePer100k": 2139.3,
+        "casesFemalePer100k": 1769.8,
+        "deathsMalePer100k": 0,
+        "deathsFemalePer100k": 0
+      },
+      "A05-A14": {
+        "casesMale": 2775,
+        "casesFemale": 2510,
+        "deathsMale": 0,
+        "deathsFemale": 0,
+        "casesMalePer100k": 3267.4,
+        "casesFemalePer100k": 3147,
+        "deathsMalePer100k": 0,
+        "deathsFemalePer100k": 0
+      },
+      "A15-A34": {
+        // ...
+      },
+      "A35-A59": {
+        // ...
+      },
+      "A60-A79": {
+        // ...
+      },
+      "A80+": {
+        // ...
+      }
+    }
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2021-05-04T01:09:15.000Z",
+    "lastCheckedForUpdate": "2021-05-04T20:45:46.210Z"
+  }
+}
+```

--- a/src/data-requests/germany.ts
+++ b/src/data-requests/germany.ts
@@ -160,3 +160,50 @@ export async function getNewRecovered(): Promise<ResponseData<number>> {
     lastUpdate: new Date(data.features[0].attributes.date),
   };
 }
+
+export interface AgeGroupData {
+  casesMale: string;
+  casesFemale: string;
+  deathsMale: string;
+  deathsFemale: string;
+  casesMalePer100k: string;
+  casesFemalePer100k: string;
+  deathsMalePer100k: string;
+  deathsFemalePer100k: string;
+}
+
+export async function getGermanyAgeGroups(): Promise<
+  ResponseData<AgeGroupData>
+> {
+  const response = await axios.get(
+    "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/rki_altersgruppen_hubv/FeatureServer/0/query?where=1%3D1&outFields=*&outSR=4326&f=json"
+  );
+  const data = response.data;
+  if (data.error) {
+    throw new RKIError(data.error, response.config.url);
+  }
+  const lastModified = response.headers["last-modified"];
+  const lastUpdate = lastModified != null ? new Date(lastModified) : new Date();
+
+  let germany_data: AgeGroupData = null;
+  data.features.forEach((feature) => {
+    // germany has BundeslandId=0
+    // skip everything else
+    if (feature.attributes.BundeslandId != 0) return;
+    germany_data = {
+      casesMale: feature.attributes.AnzFallM,
+      casesFemale: feature.attributes.AnzFallW,
+      deathsMale: feature.attributes.AnzTodesfallM,
+      deathsFemale: feature.attributes.AnzTodesfallW,
+      casesMalePer100k: feature.attributes.AnzFall100kM,
+      casesFemalePer100k: feature.attributes.AnzFall100kW,
+      deathsMalePer100k: feature.attributes.AnzTodesfall100kM,
+      deathsFemalePer100k: feature.attributes.AnzTodesfall100kW,
+    };
+  });
+
+  return {
+    data: germany_data,
+    lastUpdate,
+  };
+}

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -9,6 +9,8 @@ import {
   getRecovered,
   getLastDeathsHistory,
   getLastRecoveredHistory,
+  getGermanyAgeGroups,
+  AgeGroupData,
 } from "../data-requests/germany";
 import { getRValue } from "../data-requests/r-value";
 import { getStatesData } from "../data-requests/states";
@@ -150,5 +152,16 @@ export async function GermanyRecoveredHistoryResponse(
   return {
     data: history,
     meta: new ResponseMeta(new Date(history[history.length - 1].date)),
+  };
+}
+
+export async function GermanyAgeGroupsResponse(): Promise<{
+  data: AgeGroupData;
+  meta: ResponseMeta;
+}> {
+  const AgeGroupsData = await getGermanyAgeGroups();
+  return {
+    data: AgeGroupsData.data,
+    meta: new ResponseMeta(AgeGroupsData.lastUpdate),
   };
 }

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -9,6 +9,8 @@ import {
   getStatesRecoveredData,
   IStateData,
   getNewStateRecovered,
+  getStatesAgeGroups,
+  AgeGroupsData,
 } from "../data-requests/states";
 import {
   AddDaysToDate,
@@ -380,5 +382,22 @@ export async function StatesRecoveredHistoryResponse(
   return {
     data,
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
+  };
+}
+
+export async function StatesAgeGroupsResponse(
+  abbreviation?: string
+): Promise<{
+  data: AgeGroupsData;
+  meta: ResponseMeta;
+}> {
+  let id = null;
+  if (abbreviation != null) {
+    id = getStateIdByAbbreviation(abbreviation);
+  }
+  const AgeGroupsData = await getStatesAgeGroups(id);
+  return {
+    data: AgeGroupsData.data,
+    meta: new ResponseMeta(AgeGroupsData.lastUpdate),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import {
   StatesRecoveredHistoryResponse,
   StatesResponse,
   StatesWeekIncidenceHistoryResponse,
+  StatesAgeGroupsResponse,
 } from "./responses/states";
 import {
   GermanyCasesHistoryResponse,
@@ -270,6 +271,16 @@ app.get(
   }
 );
 
+app.get(
+  "/states/age-groups",
+  queuedCache(),
+  cache.route(),
+  async (req, res) => {
+    const response = await StatesAgeGroupsResponse();
+    res.json(response);
+  }
+);
+
 app.get("/states/:state", queuedCache(), cache.route(), async (req, res) => {
   const response = await StatesResponse(req.params.state);
   res.json(response);
@@ -373,6 +384,16 @@ app.get(
       parseInt(req.params.days),
       req.params.state
     );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/:state/age-groups",
+  queuedCache(),
+  cache.route(),
+  async (req, res) => {
+    const response = await StatesAgeGroupsResponse(req.params.state);
     res.json(response);
   }
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import {
   StatesAgeGroupsResponse,
 } from "./responses/states";
 import {
+  GermanyAgeGroupsResponse,
   GermanyCasesHistoryResponse,
   GermanyDeathsHistoryResponse,
   GermanyRecoveredHistoryResponse,
@@ -170,6 +171,16 @@ app.get(
     const response = await GermanyRecoveredHistoryResponse(
       parseInt(req.params.days)
     );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/germany/age-groups",
+  queuedCache(),
+  cache.route(),
+  async (req, res) => {
+    const response = await GermanyAgeGroupsResponse();
     res.json(response);
   }
 );


### PR DESCRIPTION
This pull request adds the feature to display the number of cases and more for the States and Germany as a whole, broken down by age group.

the data is from [rki via arcgis](https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/23b1ccb051f543a5b526021275c1c6e5_0)


fix  #137