### PR TITLE
Fix date in frozen-incidence.ts

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import XLSX from "xlsx";
-import { getDateBefore, RKIError } from "../utils";
+import { AddDaysToDate, getDateBefore, RKIError } from "../utils";
 import { ResponseData } from "./response-data";
 
 export interface FrozenIncidenceData {
@@ -50,8 +50,9 @@ export async function getFrozenIncidenceHistory(
     // ignore the first three elements (rowNumber, LK, LKNR)
     dateKeys.splice(0, 3);
     dateKeys.forEach((dateKey) => {
-      const date = new Date(
-        dateKey.toString().replace(date_pattern, "$3-$2-$1")
+      const date = AddDaysToDate(
+        new Date(dateKey.toString().replace(date_pattern, "$3-$2-$1")),
+        -1
       );
       history.push({ weekIncidence: district[dateKey], date });
     });


### PR DESCRIPTION
This patch subs one day from the dates in frozen-incidence list to align with all other history dates, as discussed in #217 and #220.
Fix #217
Fix #220 