### PR TITLE
Fix excel sheet name for frozen incidence endpoint

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -28,7 +28,7 @@ export async function getFrozenIncidenceHistory(
   }
 
   var workbook = XLSX.read(data, { type: "buffer", cellDates: true });
-  const sheet = workbook.Sheets["LK_7-Tage-Inzidenz"];
+  const sheet = workbook.Sheets["LK_7-Tage-Inzidenz (fixiert)"];
   // table starts in row 5 (parameter is zero indexed)
   const json = XLSX.utils.sheet_to_json(sheet, { range: 4 });
 


### PR DESCRIPTION
The RKI changed the sheet name for the frozen incidences starting on 25th of May. This causes the frozen incidene api to break:

Response from https://api.corona-zahlen.org/districts/03101/history/frozen-incidence at the moment:

```
{
  "error": {
    "message": "An error occurred.",
    "details": "Cannot read property 'A2' of undefined",
    "stack": "TypeError: Cannot read property 'A2' of undefined\n    at Object.<anonymous> (/usr/src/app/src/data-requests/frozen-incidence.ts:37:27)\n    at Generator.next (<anonymous>)\n    at fulfilled (/usr/src/app/dist/data-requests/frozen-incidence.js:5:58)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)"
  }
}
```