### PR TITLE
Fix interface for FrozenIncidenceData

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -7,8 +7,8 @@ export interface FrozenIncidenceData {
   ags: string;
   name: string;
   history: {
-    date: string;
-    value: number;
+    date: Date;
+    weekIncidence: number;
   }[];
 }
 


### PR DESCRIPTION
The code uses `weekIncidence` instead of `value` and the `date` key contains a `Date` and not a string. I opted to fix the interface definition, as the correct names are used at the call-site.