### PR TITLE
Add ImpfPush project

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Now you can access the server at `http://localhost:8080`.
 - CoronaBot Deutschland (https://twitter.com/CoronaBot_DEU)
 - Fallzahlen Aktuell - Inzidenz & mehr aus DE
   (https://play.google.com/store/apps/details?id=com.kokoschka.michael.casestoday&hl=de)
+- ImpfPush - Benachrichtigung über aktuelle Inzidenz-Zahlen aus Ihrer Region (https://www.impfpush.de)
 - Home Assistant Integration (https://github.com/thebino/rki_covid)
 - Corona Charts für Deutschland (https://corona.maximilianhaindl.de)
 - Corona Infos für das Berchtesgadener Land mit Zusatzinfos (https://covid.webreload.de/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,7 @@ Now you can access the server at `http://localhost:8080`.
 
 - CoronaBot Deutschland [https://twitter.com/CoronaBot_DEU](https://twitter.com/CoronaBot_DEU)
 - Fallzahlen Aktuell - Inzidenz & mehr aus DE [https://play.google.com/store/apps/details?id=com.kokoschka.michael.casestoday&hl=de](https://play.google.com/store/apps/details?id=com.kokoschka.michael.casestoday&hl=de)
+- ImpfPush - Benachrichtigung über aktuelle Inzidenz-Zahlen aus Ihrer Region [https://www.impfpush.de](https://www.impfpush.de)
 - Home Assistant Integration [https://github.com/thebino/rki_covid](https://github.com/thebino/rki_covid)
 - Corona Charts für Deutschland [https://corona.maximilianhaindl.de](https://corona.maximilianhaindl.de)
 - Corona Infos für das Berchtesgadener Land mit Zusatzinfos [https://covid.webreload.de/](https://covid.webreload.de/)


### PR DESCRIPTION
Originally, I started this project to provide a (self-hostable) service like VaxBot (https://monal.im/blog/xmpp-ending-this-pandemic-part-1/) for Germany. This was when I bought the domain, so it still has that name...

But the lack of publicly available appointment data made the project impossible, so I implemented a bot that sends the incidence value of your preferred location, subscribed by zip code, every morning.

Source code is available on EduGit.org/ImpfPush