### PR TITLE
Set the imagequality of the maps to 25 to prevent colorerrors

### DIFF
--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -33,7 +33,7 @@ export async function DistrictsMapResponse() {
 
   const svgBuffer = Buffer.from(stringify(mapData));
 
-  return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
+  return sharp(svgBuffer).png({ quality: 25 }).toBuffer();
 }
 
 export async function StatesMapResponse() {
@@ -63,7 +63,7 @@ export async function StatesMapResponse() {
 
   const svgBuffer = Buffer.from(stringify(mapData));
 
-  return sharp(svgBuffer).png({ quality: 5 }).toBuffer();
+  return sharp(svgBuffer).png({ quality: 25 }).toBuffer();
 }
 
 export function IncidenceColorsResponse() {


### PR DESCRIPTION
Set the imagequality of the maps to 25 to prevent colorerrors as described in issue #254 
Fix #254 