### PR TITLE
Set r: and rValue4Days: to null

### DIFF
--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -7,6 +7,8 @@
 `GET https://api.corona-zahlen.org/germany`
 [Open](/germany)
 
+-ATTENTION- after 2021-07-17 the 4-day r-value is not provided by RKI anymore
+
 ### Response
 
 ```json
@@ -23,9 +25,9 @@
     "recovered": 883
   },
   "r": {
-    "value": 1.19,
+    "value": null,
     "rValue4Days": {
-      "value": 1.19,
+      "value": null,
       "date": "2021-07-01T00:00:00.000Z"
     },
     "rValue7Days": {

--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -7,7 +7,7 @@
 `GET https://api.corona-zahlen.org/germany`
 [Open](/germany)
 
--ATTENTION- after 2021-07-17 the 4-day r-value is not provided by RKI anymore
+-ATTENTION- The 4-day r-value is no longer provided since July 17, 2021 by RKI
 
 ### Response
 

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -20,7 +20,7 @@ function parseRValue(
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
   const rValue4Days = null as number; // no longer provided by RKI
-  
+
   let rValue7DaysDateString = latestEntry["Datum"];
   let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];
   if (rValue7Days == null) {

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -19,6 +19,7 @@ function parseRValue(
 
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
+  const rValue4Days = null; //no longer provided by RKI
   
   let rValue7DaysDateString = latestEntry["Datum"];
   let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -19,7 +19,7 @@ function parseRValue(
 
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
-  const rValue4Days = null; //no longer provided by RKI
+  const rValue4Days = null; // no longer provided by RKI
   
   let rValue7DaysDateString = latestEntry["Datum"];
   let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -19,7 +19,7 @@ function parseRValue(
 
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
-  const rValue4Days = null; // no longer provided by RKI
+  const rValue4Days = null as number; // no longer provided by RKI
   
   let rValue7DaysDateString = latestEntry["Datum"];
   let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -19,14 +19,13 @@ function parseRValue(
 
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
-  let rValue4Days = latestEntry["OG_PI_4_Tage_R_Wert"] as number;
-
+  
   let rValue7DaysDateString = latestEntry["Datum"];
-  let rValue7Days = latestEntry["OG_PI_7_Tage_R_Wert"];
+  let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];
   if (rValue7Days == null) {
     const entry = json[json.length - 2];
     rValue7DaysDateString = entry["Datum"];
-    rValue7Days = entry["OG_PI_7_Tage_R_Wert"];
+    rValue7Days = entry["PS_7_Tage_R_Wert"];
   }
 
   const rValue4DaysDate = new Date(rValue4DaysDateString);

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -87,8 +87,8 @@ export async function GermanyResponse(): Promise<GermanyData> {
       recovered: newRecoveredData.data,
     },
     r: {
-      value: rData.data.rValue4Days.value, // legacy
-      rValue4Days: rData.data.rValue4Days,
+      value: null // rData.data.rValue4Days.value, // legacy, since 2021-07-17 the value is not published by RKI
+      rValue4Days: null // rData.data.rValue4Days, see ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       rValue7Days: rData.data.rValue7Days,
       date: rData.lastUpdate,
     },

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -87,8 +87,8 @@ export async function GermanyResponse(): Promise<GermanyData> {
       recovered: newRecoveredData.data,
     },
     r: {
-      value: null, // rData.data.rValue4Days.value, legacy but since 2021-07-17 the value is not published by RKI
-      rValue4Days: null, // rData.data.rValue4Days, see ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      value: rData.data.rValue4Days.value, //legacy
+      rValue4Days: rData.data.rValue4Days,
       rValue7Days: rData.data.rValue7Days,
       date: rData.lastUpdate,
     },

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -87,8 +87,8 @@ export async function GermanyResponse(): Promise<GermanyData> {
       recovered: newRecoveredData.data,
     },
     r: {
-      value: null // rData.data.rValue4Days.value, // legacy, since 2021-07-17 the value is not published by RKI
-      rValue4Days: null // rData.data.rValue4Days, see ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      value: null, // rData.data.rValue4Days.value, legacy but since 2021-07-17 the value is not published by RKI
+      rValue4Days: null, // rData.data.rValue4Days, see ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       rValue7Days: rData.data.rValue7Days,
       date: rData.lastUpdate,
     },

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -87,7 +87,7 @@ export async function GermanyResponse(): Promise<GermanyData> {
       recovered: newRecoveredData.data,
     },
     r: {
-      value: rData.data.rValue4Days.value, //legacy
+      value: rData.data.rValue4Days.value, // legacy
       rValue4Days: rData.data.rValue4Days,
       rValue7Days: rData.data.rValue7Days,
       date: rData.lastUpdate,


### PR DESCRIPTION
Since 2021-07-17 the 4-day r-value will not be published by RKI anymore
Fix #256  (not realy fixed, but ..................)
Fix #258 