### PR TITLE
Calculate not provided 4-day r-value and fix the r-value to the middle

### DIFF
--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -20,7 +20,7 @@ function parseRValue(
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
   // since 2021-07-17 the RKI no longer provide the 4-day-r-value
-  // so the value is to be caltuleted
+  // so that the value has to be calculated
   let numerator = 0 as number;
   for (let Offset = 1; Offset < 5; Offset++) {
     numerator += json[json.length - Offset]["PS_COVID_Faelle"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -61,8 +61,11 @@ export async function getRValue() {
   );
   const data = response.data;
   const rData = parseRValue(data);
+  const meta = await axios.get(
+    `https://github.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/raw/main/.zenodo.json`
+  );
   return {
     data: rData,
-    lastUpdate: AddDaysToDate(rData.rValue4Days.date, 4), // the lastUpdate Date is rValue4Days.date + 4 Days
+    lastUpdate: new Date(meta.data.publication_date),
   };
 }

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -21,14 +21,22 @@ function parseRValue(
   const rValue4DaysDateString = latestEntry["Datum"];
   // since 2021-07-17 the RKI no longer provide the 4-day-r-value
   // so the value is to be caltuleted
-  let rValue4Days = latestEntry["OG_PI_4_Tage_R_Wert"] as number;
+  let numerator = 0 as number;
+  for (let Offset = 1; Offset < 5; Offset++) {
+    numerator += json[json.length - Offset]["PS_COVID_Faelle"];
+  }
+  let denominator = 0 as number;
+  for (let Offset = 5; Offset < 9; Offset++) {
+    denominator += json[json.length - Offset]["PS_COVID_Faelle"];
+  }
+  const rValue4Days = Math.round(numerator / denominator * 100) / 100;
 
   let rValue7DaysDateString = latestEntry["Datum"];
-  let rValue7Days = latestEntry["OG_PI_7_Tage_R_Wert"];
+  let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];
   if (rValue7Days == null) {
     const entry = json[json.length - 2];
     rValue7DaysDateString = entry["Datum"];
-    rValue7Days = entry["OG_PI_7_Tage_R_Wert"];
+    rValue7Days = entry["PS_7_Tage_R_Wert"];
   }
 
   const rValue4DaysDate = new Date(rValue4DaysDateString);

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import XLSX from "xlsx";
+import { AddDaysToDate } from "../utils";
 
 function parseRValue(
   data: ArrayBuffer
@@ -31,13 +32,10 @@ function parseRValue(
   }
   const rValue4Days = Math.round((numerator / denominator) * 100) / 100;
 
-  let rValue7DaysDateString = latestEntry["Datum"];
-  let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];
-  if (rValue7Days == null) {
-    const entry = json[json.length - 2];
-    rValue7DaysDateString = entry["Datum"];
-    rValue7Days = entry["PS_7_Tage_R_Wert"];
-  }
+  // the 7-day r-value is always one day bevor the 4-day r-value!
+  const entry = json[json.length - 2];
+  const rValue7DaysDateString = entry["Datum"];
+  const rValue7Days = entry["PS_7_Tage_R_Wert"];
 
   const rValue4DaysDate = new Date(rValue4DaysDateString);
   const rValue7DaysDate = new Date(rValue7DaysDateString);
@@ -65,6 +63,6 @@ export async function getRValue() {
   const rData = parseRValue(data);
   return {
     data: rData,
-    lastUpdate: rData.rValue7Days.date,
+    lastUpdate: AddDaysToDate(rData.rValue4Days.date, 4), // the lastUpdate Date is rValue4Days.date + 4 Days
   };
 }

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -21,17 +21,21 @@ function parseRValue(
   const rValue4DaysDateString = latestEntry["Datum"];
   // since 2021-07-17 the RKI no longer provide the 4-day-r-value
   // so that the value has to be calculated
-  let numerator = 0 as number;
-  for (let Offset = 1; Offset < 5; Offset++) {
-    numerator += json[json.length - Offset]["PS_COVID_Faelle"];
+
+  // sum of the daily cases in the last 4 days
+  let numerator = 0;
+  for (let offset = 1; offset < 5; offset++) {
+    numerator += json[json.length - offset]["PS_COVID_Faelle"];
   }
-  let denominator = 0 as number;
-  for (let Offset = 5; Offset < 9; Offset++) {
-    denominator += json[json.length - Offset]["PS_COVID_Faelle"];
+
+  // sum of four daily cases 4 days ago
+  let denominator = 0;
+  for (let offset = 5; offset < 9; offset++) {
+    denominator += json[json.length - offset]["PS_COVID_Faelle"];
   }
   const rValue4Days = Math.round((numerator / denominator) * 100) / 100;
 
-  // the 7-day r-value is always one day bevor the 4-day r-value!
+  // the 7-day r-value is always one day before the 4-day r-value!
   const entry = json[json.length - 2];
   const rValue7DaysDateString = entry["Datum"];
   const rValue7Days = entry["PS_7_Tage_R_Wert"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
 import XLSX from "xlsx";
-import { AddDaysToDate } from "../utils";
 
 function parseRValue(
   data: ArrayBuffer

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -19,6 +19,8 @@ function parseRValue(
 
   const latestEntry = json[json.length - 1];
   const rValue4DaysDateString = latestEntry["Datum"];
+  // since 2021-07-17 the RKI no longer provide the 4-day-r-value
+  // so the value is to be caltuleted
   let rValue4Days = latestEntry["OG_PI_4_Tage_R_Wert"] as number;
 
   let rValue7DaysDateString = latestEntry["Datum"];

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -29,7 +29,7 @@ function parseRValue(
   for (let Offset = 5; Offset < 9; Offset++) {
     denominator += json[json.length - Offset]["PS_COVID_Faelle"];
   }
-  const rValue4Days = Math.round(numerator / denominator * 100) / 100;
+  const rValue4Days = Math.round((numerator / denominator) * 100) / 100;
 
   let rValue7DaysDateString = latestEntry["Datum"];
   let rValue7Days = latestEntry["PS_7_Tage_R_Wert"];

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -32,7 +32,7 @@ interface GermanyData extends IResponseMeta {
       value: number;
       date: Date;
     };
-    date: Date;
+    lastUpdate_rValues: Date;
   };
   delta: {
     cases: number;
@@ -90,7 +90,7 @@ export async function GermanyResponse(): Promise<GermanyData> {
       value: rData.data.rValue4Days.value, // legacy
       rValue4Days: rData.data.rValue4Days,
       rValue7Days: rData.data.rValue7Days,
-      date: rData.lastUpdate,
+      lastUpdate_rValues: rData.lastUpdate,
     },
     meta: new ResponseMeta(statesData.lastUpdate),
   };

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -32,7 +32,7 @@ interface GermanyData extends IResponseMeta {
       value: number;
       date: Date;
     };
-    lastUpdate_rValues: Date;
+    lastUpdate: Date;
   };
   delta: {
     cases: number;
@@ -90,7 +90,7 @@ export async function GermanyResponse(): Promise<GermanyData> {
       value: rData.data.rValue4Days.value, // legacy
       rValue4Days: rData.data.rValue4Days,
       rValue7Days: rData.data.rValue7Days,
-      lastUpdate_rValues: rData.lastUpdate,
+      lastUpdate: rData.lastUpdate,
     },
     meta: new ResponseMeta(statesData.lastUpdate),
   };


### PR DESCRIPTION
I fist decided to set the not by RKI provided 4-day r-value to null.
as a alternative here the 4-day r-value is calculated with the nowcastvalues provided by RKI
by merging this PR the PR #257 is obsolate.
Secont thing is that thisone fix the Issue that the upper limit of the r-values are provided and not the middel!

Fix #256 
Fix #258 
