### PR TITLE
Filter out notice from list of districts in frozen incidence excel file

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -39,30 +39,34 @@ export async function getFrozenIncidenceHistory(
     .replace(date_pattern, "$3-$2-$1");
   const lastUpdate = new Date(dateString);
 
-  let districts = json.map((district) => {
-    const name = district["LK"];
-    const ags = district["LKNR"].toString().padStart(5, "0");
+  let districts = json
+    .filter((district) => !!district["NR"])
+    .map((district) => {
+      console.log(district);
+      const name = district["LK"];
+      const ags = district["LKNR"].toString().padStart(5, "0");
 
-    let history = [];
+      let history = [];
 
-    // get all date keys
-    const dateKeys = Object.keys(district);
-    // ignore the first three elements (rowNumber, LK, LKNR)
-    dateKeys.splice(0, 3);
-    dateKeys.forEach((dateKey) => {
-      const date = new Date(
-        dateKey.toString().replace(date_pattern, "$3-$2-$1")
-      );
-      history.push({ weekIncidence: district[dateKey], date });
+      // get all date keys
+      const dateKeys = Object.keys(district);
+      // ignore the first three elements (rowNumber, LK, LKNR)
+      dateKeys.splice(0, 3);
+      dateKeys.forEach((dateKey) => {
+        const date = AddDaysToDate(
+          new Date(dateKey.toString().replace(date_pattern, "$3-$2-$1")),
+          -1
+        );
+        history.push({ weekIncidence: district[dateKey], date });
+      });
+
+      if (days != null) {
+        const reference_date = new Date(getDateBefore(days));
+        history = history.filter((element) => element.date > reference_date);
+      }
+
+      return { ags, name, history };
     });
-
-    if (days != null) {
-      const reference_date = new Date(getDateBefore(days));
-      history = history.filter((element) => element.date > reference_date);
-    }
-
-    return { ags, name, history };
-  });
 
   if (ags != null) {
     districts = districts.filter((district) => district.ags === ags);

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -42,7 +42,6 @@ export async function getFrozenIncidenceHistory(
   let districts = json
     .filter((district) => !!district["NR"])
     .map((district) => {
-      console.log(district);
       const name = district["LK"];
       const ags = district["LKNR"].toString().padStart(5, "0");
 
@@ -53,9 +52,8 @@ export async function getFrozenIncidenceHistory(
       // ignore the first three elements (rowNumber, LK, LKNR)
       dateKeys.splice(0, 3);
       dateKeys.forEach((dateKey) => {
-        const date = AddDaysToDate(
-          new Date(dateKey.toString().replace(date_pattern, "$3-$2-$1")),
-          -1
+        const date = new Date(
+          dateKey.toString().replace(date_pattern, "$3-$2-$1")
         );
         history.push({ weekIncidence: district[dateKey], date });
       });


### PR DESCRIPTION
The RKI added a notice to the bottom of the district list that some districts got merged into one district, that broke the parsing:

<img width="658" alt="Bildschirmfoto 2021-08-03 um 13 44 25" src="https://user-images.githubusercontent.com/42106/128009842-4be41d61-b252-424a-9926-5c7cb4d4133a.png">
