### PR TITLE
set quality setting for png image to 75 to prevent artefacte

### DIFF
--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -33,7 +33,7 @@ export async function DistrictsMapResponse() {
 
   const svgBuffer = Buffer.from(stringify(mapData));
 
-  return sharp(svgBuffer).png({ quality: 25 }).toBuffer();
+  return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
 export async function StatesMapResponse() {
@@ -63,7 +63,7 @@ export async function StatesMapResponse() {
 
   const svgBuffer = Buffer.from(stringify(mapData));
 
-  return sharp(svgBuffer).png({ quality: 25 }).toBuffer();
+  return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
 export function IncidenceColorsResponse() {


### PR DESCRIPTION
as shown in #273 there are still some artefacte. The actual quality setting of 25 is not high enough. Tested 50 but there are still the same artefacte! it seems that 75 is high enough. Maybe the setting shoud be 100 to bury the bug forever, your decision
Fix #273