### PR TITLE
Add Corona Zahlen in Deutschland (Wordpress Plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Now you can access the server at `http://localhost:8080`.
 - Fallzahlen Statistik App (https://play.google.com/store/apps/details?id=com.companyname.statforms)
 - Germany Covidometer (https://arashesdr.github.io/covidometer/)
 - Pandemie jetzt (https://pandemie.jetzt/)
+- Corona Zahlen in Deutschland (Wordpress Plugin) (https://de.wordpress.org/plugins/corona-zahlen-deutschland-cng/)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,7 +158,6 @@ Now you can access the server at `http://localhost:8080`.
 - Pandemie jetzt [https://pandemie.jetzt/](https://pandemie.jetzt/)
 - Corona Zahlen in Deutschland (Wordpress Plugin) [https://de.wordpress.org/plugins/corona-zahlen-deutschland-cng/](https://de.wordpress.org/plugins/corona-zahlen-deutschland-cng/)
 
-
 ## License
 
 <p xmlns:dct="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" class="license-text"><a rel="cc:attributionURL" property="dct:title" href="https://rki.marlon-lueckert.de">rki-covid-api</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://marlon-lueckert.de">Marlon Lückert</a> is licensed under <a rel="license" href="https://creativecommons.org/licenses/by/4.0">CC BY 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" /><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" /></a></p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,8 @@ Now you can access the server at `http://localhost:8080`.
 - Fallzahlen Statistik App [https://play.google.com/store/apps/details?id=com.companyname.statforms](https://play.google.com/store/apps/details?id=com.companyname.statforms)
 - Germany Covidometer [https://arashesdr.github.io/covidometer/](https://arashesdr.github.io/covidometer/)
 - Pandemie jetzt [https://pandemie.jetzt/](https://pandemie.jetzt/)
+- Corona Zahlen in Deutschland (Wordpress Plugin) [https://de.wordpress.org/plugins/corona-zahlen-deutschland-cng/](https://de.wordpress.org/plugins/corona-zahlen-deutschland-cng/)
+
 
 ## License
 


### PR DESCRIPTION
Add the project Corona Zahlen in Deutschland (Wordpress Plugin) to the showcase (#147).