### PR TITLE
add frozen incidence to germany and states

### DIFF
--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -575,31 +575,31 @@ Returns the number of recovered people in germany for the last `:days` days.
     "history": [
       {
         "weekIncidence": 213.65875024446805,
-        "date": "2021-11-08T23:00:00.000Z"
+        "date": "2021-11-09T00:00:00.000Z"
       },
       {
         "weekIncidence": 232.1218544191271,
-        "date": "2021-11-09T23:00:00.000Z"
+        "date": "2021-11-10T00:00:00.000Z"
       },
       {
         "weekIncidence": 249.11060402346553,
-        "date": "2021-11-10T23:00:00.000Z"
+        "date": "2021-11-11T00:00:00.000Z"
       },
       {
         "weekIncidence": 263.69059979064883,
-        "date": "2021-11-11T23:00:00.000Z"
+        "date": "2021-11-12T00:00:00.000Z"
       },
       {
         "weekIncidence": 277.35784260606,
-        "date": "2021-11-12T23:00:00.000Z"
+        "date": "2021-11-13T00:00:00.000Z"
       },
       {
         "weekIncidence": 288.962672625304,
-        "date": "2021-11-13T23:00:00.000Z"
+        "date": "2021-11-14T00:00:00.000Z"
       },
       {
         "weekIncidence": 302.97505390864444,
-        "date": "2021-11-14T23:00:00.000Z"
+        "date": "2021-11-15T00:00:00.000Z"
       }
     ]
   },
@@ -607,8 +607,8 @@ Returns the number of recovered people in germany for the last `:days` days.
     "source": "Robert Koch-Institut",
     "contact": "Marlon Lueckert (m.lueckert@me.com)",
     "info": "https://github.com/marlon360/rki-covid-api",
-    "lastUpdate": "2021-11-15T06:26:37.000Z",
-    "lastCheckedForUpdate": "2021-11-15T19:18:18.245Z"
+    "lastUpdate": "2021-11-15T07:26:37.000Z",
+    "lastCheckedForUpdate": "2021-11-15T21:12:27.928Z"
   }
 }
 ```

--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -549,3 +549,66 @@ Returns the number of recovered people in germany for the last `:days` days.
   }
 }
 ```
+
+## `/germany/history/frozen-incidence`
+
+## `/germany/history/frozen-incidence/:days`
+
+### Request
+
+`GET https://api.corona-zahlen.org/germany/history/frozen-incidence/7`
+[Open](/germany/history/frozen-incidence/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |
+
+### Response
+
+```json
+{
+  "data": {
+    "abbreviation": "Bund",
+    "name": "Bundesgebiet",
+    "history": [
+      {
+        "weekIncidence": 213.65875024446805,
+        "date": "2021-11-08T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 232.1218544191271,
+        "date": "2021-11-09T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 249.11060402346553,
+        "date": "2021-11-10T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 263.69059979064883,
+        "date": "2021-11-11T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 277.35784260606,
+        "date": "2021-11-12T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 288.962672625304,
+        "date": "2021-11-13T23:00:00.000Z"
+      },
+      {
+        "weekIncidence": 302.97505390864444,
+        "date": "2021-11-14T23:00:00.000Z"
+      }
+    ]
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2021-11-15T06:26:37.000Z",
+    "lastCheckedForUpdate": "2021-11-15T19:18:18.245Z"
+  }
+}
+```

--- a/docs/endpoints/states.md
+++ b/docs/endpoints/states.md
@@ -155,6 +155,21 @@ Redirects to `/states/history/cases`
 
 ## `/states/history/incidence/:days`
 
+## `/states/history/frozen-incidence`
+
+## `/states/history/frozen-incidence/:days`
+
+### Request
+
+`GET https://api.corona-zahlen.org/states/history/frozen-incidence/7`
+[Open](/states/history/frozen-incidence/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |
+
 ## `/states/history/deaths`
 
 ## `/states/history/deaths/:days`
@@ -257,6 +272,22 @@ Redirects to `/states/history/cases`
 ## `/states/:state/history/incidence`
 
 ## `/states/:state/history/incidence/:days`
+
+## `/states/:state/history/frozen-incidence`
+
+## `/states/:state/history/frozen-incidence/:days`
+
+### Request
+
+`GET https://api.corona-zahlen.org/states/HH/history/frozen-incidence/7`
+[Open](/states/HH/history/frozen-incidence/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |
+| :states   | Abbreviation of the state             |
 
 ## `/states/:state/history/deaths`
 

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -1,6 +1,11 @@
 import axios from "axios";
 import XLSX from "xlsx";
-import { getDateBefore, RKIError } from "../utils";
+import {
+  getDateBefore,
+  getStateAbbreviationById,
+  getStateAbbreviationByName,
+  RKIError,
+} from "../utils";
 import { ResponseData } from "./response-data";
 
 export interface FrozenIncidenceData {
@@ -59,7 +64,7 @@ export async function getFrozenIncidenceHistory(
       });
 
       if (days != null) {
-        const reference_date = new Date(getDateBefore(days));
+        const reference_date = new Date(getDateBefore(days - 1));
         history = history.filter((element) => element.date > reference_date);
       }
 
@@ -72,6 +77,77 @@ export async function getFrozenIncidenceHistory(
 
   return {
     data: districts,
+    lastUpdate: lastUpdate,
+  };
+}
+
+export interface StatesFrozenIncidenceData {
+  abbreviation: string;
+  name: string;
+  history: {
+    date: Date;
+    weekIncidence: number;
+  }[];
+}
+
+export async function getStatesFrozenIncidenceHistory(
+  days?: number,
+  abbreviation?: string
+): Promise<ResponseData<StatesFrozenIncidenceData[]>> {
+  const response = await axios.get(
+    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile",
+    {
+      responseType: "arraybuffer",
+    }
+  );
+  const data = response.data;
+  if (data.error) {
+    throw new RKIError(data.error, response.config.url);
+  }
+
+  var workbook = XLSX.read(data, { type: "buffer", cellDates: true });
+  const sheet = workbook.Sheets["BL_7-Tage-Inzidenz (fixiert)"];
+  // table starts in row 3 (parameter is zero indexed)
+  const json = XLSX.utils.sheet_to_json(sheet, { range: 2 });
+
+  // date is in cell A2
+  const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
+  const dateString = sheet["A2"].v
+    .replace("Stand: ", "")
+    .replace(date_pattern, "$3-$2-$1");
+  const lastUpdate = new Date(dateString);
+
+  let states = json.map((states) => {
+    const name = states["__EMPTY"];
+    const abbreviation = getStateAbbreviationByName(name);
+
+    let history = [];
+
+    // get all date keys
+    const dateKeys = Object.keys(states);
+    // ignore the first three elements (rowNumber, LK, LKNR)
+    dateKeys.splice(0, 1);
+    dateKeys.forEach((dateKey) => {
+      const date = new Date(
+        dateKey.toString().replace(date_pattern, "$3-$2-$1")
+      );
+      history.push({ weekIncidence: states[dateKey], date });
+    });
+
+    if (days != null) {
+      const reference_date = new Date(getDateBefore(days - 1));
+      history = history.filter((element) => element.date > reference_date);
+    }
+
+    return { abbreviation, name, history };
+  });
+
+  if (abbreviation != null) {
+    states = states.filter((states) => states.abbreviation === abbreviation);
+  }
+
+  return {
+    data: states,
     lastUpdate: lastUpdate,
   };
 }

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -118,14 +118,14 @@ export async function getStatesFrozenIncidenceHistory(
   const lastUpdate = new Date(dateString);
 
   let states = json.map((states) => {
-    const name = states["__EMPTY"];
+    const name = states["__EMPTY"]; //there is no header
     const abbreviation = getStateAbbreviationByName(name);
 
     let history = [];
 
     // get all date keys
     const dateKeys = Object.keys(states);
-    // ignore the first three elements (rowNumber, LK, LKNR)
+    // ignore the first element (witch is the state)
     dateKeys.splice(0, 1);
     dateKeys.forEach((dateKey) => {
       const date = new Date(

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -64,7 +64,7 @@ export async function getFrozenIncidenceHistory(
       });
 
       if (days != null) {
-        const reference_date = new Date(getDateBefore(days - 1));
+        const reference_date = new Date(getDateBefore(days));
         history = history.filter((element) => element.date > reference_date);
       }
 
@@ -135,7 +135,7 @@ export async function getStatesFrozenIncidenceHistory(
     });
 
     if (days != null) {
-      const reference_date = new Date(getDateBefore(days - 1));
+      const reference_date = new Date(getDateBefore(days));
       history = history.filter((element) => element.date > reference_date);
     }
 

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -18,6 +18,10 @@ import {
   getHospitalizationData,
   getLatestHospitalizationDataKey,
 } from "../data-requests/hospitalization";
+import {
+  getStatesFrozenIncidenceHistory,
+  StatesFrozenIncidenceData,
+} from "../data-requests/frozen-incidence";
 
 interface GermanyData extends IResponseMeta {
   cases: number;
@@ -227,5 +231,31 @@ export async function GermanyAgeGroupsResponse(): Promise<{
   return {
     data: data,
     meta: new ResponseMeta(AgeGroupsData.lastUpdate),
+  };
+}
+
+interface StatesFrozenIncidenceHistoryData extends IResponseMeta {
+  data: {};
+}
+
+export async function GermanyFrozenIncidenceHistoryResponse(
+  days?: number
+): Promise<StatesFrozenIncidenceHistoryData> {
+  const frozenIncidenceHistoryData = await getStatesFrozenIncidenceHistory(
+    days
+  );
+
+  let data = {};
+  frozenIncidenceHistoryData.data.forEach((historyData) => {
+    if (historyData.abbreviation == null) {
+      historyData.abbreviation = "Bund";
+      historyData.name = "Bundesgebiet";
+      data = historyData;
+    }
+  });
+
+  return {
+    data: data,
+    meta: new ResponseMeta(frozenIncidenceHistoryData.lastUpdate),
   };
 }

--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -157,7 +157,8 @@ function getMapBackground(
   ranges: ColorRange[]
 ): Buffer {
   const border = 32; // for the legend, left and down
-  const yStartPosition = 1000 - border * 2; // start position from the bottom, add new ranges above
+  const rectsidesize = 30; //x and y of the rects
+  const yStartPosition = 1000 - rectsidesize; // start position from the bottom, add new ranges above
   const lastUpdateLocaleString = lastUpdate.toLocaleDateString("de-DE", {
     year: "numeric",
     month: "2-digit",
@@ -174,7 +175,7 @@ function getMapBackground(
         <text id="Stand:-22.11.2021" font-family="Helvetica" font-size="22" font-weight="normal" fill="#010501">
           <tspan x="41" y="103">Stand: ${lastUpdateLocaleString}</tspan>
         </text>
-        <g id="Legend" transform="translate(${border}, 0)">
+        <g id="Legend" transform="translate(${border}, -${border})">
         ${ranges.map((range, index) => {
           return `
           <g transform="translate(0, ${yStartPosition - index * 40})">

--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -157,8 +157,8 @@ function getMapBackground(
   ranges: ColorRange[]
 ): Buffer {
   const border = 32; // for the legend, left and down
-  const rectsidesize = 30; //x and y of the rects
-  const yStartPosition = 1000 - rectsidesize; // start position from the bottom, add new ranges above
+  const rectsize = 30; //x and y of the rects
+  const yStartPosition = 1000 - rectsize; // start position from the bottom, add new ranges above
   const lastUpdateLocaleString = lastUpdate.toLocaleDateString("de-DE", {
     year: "numeric",
     month: "2-digit",

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -25,6 +25,10 @@ import {
   getHospitalizationData,
   getLatestHospitalizationDataKey,
 } from "../data-requests/hospitalization";
+import {
+  StatesFrozenIncidenceData,
+  getStatesFrozenIncidenceHistory,
+} from "../data-requests/frozen-incidence";
 
 interface StateData extends IStateData {
   abbreviation: string;
@@ -457,5 +461,33 @@ export async function StatesAgeGroupsResponse(abbreviation?: string): Promise<{
   return {
     data: data,
     meta: new ResponseMeta(AgeGroupsData.lastUpdate),
+  };
+}
+
+interface StatesFrozenIncidenceHistoryData extends IResponseMeta {
+  data: {
+    [key: string]: StatesFrozenIncidenceData;
+  };
+}
+
+export async function StatesFrozenIncidenceHistoryResponse(
+  days?: number,
+  abbreviation?: string
+): Promise<StatesFrozenIncidenceHistoryData> {
+  const frozenIncidenceHistoryData = await getStatesFrozenIncidenceHistory(
+    days,
+    abbreviation
+  );
+
+  let data = {};
+  frozenIncidenceHistoryData.data.forEach((historyData) => {
+    if (historyData.abbreviation != null) {
+      data[historyData.abbreviation] = historyData;
+    }
+  });
+
+  return {
+    data: data,
+    meta: new ResponseMeta(frozenIncidenceHistoryData.lastUpdate),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import {
   StatesResponse,
   StatesWeekIncidenceHistoryResponse,
   StatesAgeGroupsResponse,
+  StatesFrozenIncidenceHistoryResponse,
 } from "./responses/states";
 import {
   GermanyAgeGroupsResponse,
@@ -21,6 +22,7 @@ import {
   GermanyRecoveredHistoryResponse,
   GermanyResponse,
   GermanyWeekIncidenceHistoryResponse,
+  GermanyFrozenIncidenceHistoryResponse,
 } from "./responses/germany";
 import {
   DistrictsCasesHistoryResponse,
@@ -135,6 +137,28 @@ app.get(
   cache.route(),
   async function (req, res) {
     const response = await GermanyWeekIncidenceHistoryResponse(
+      parseInt(req.params.days)
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/germany/history/frozen-incidence",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await GermanyFrozenIncidenceHistoryResponse();
+    res.json(response);
+  }
+);
+
+app.get(
+  "/germany/history/frozen-incidence/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await GermanyFrozenIncidenceHistoryResponse(
       parseInt(req.params.days)
     );
     res.json(response);
@@ -293,6 +317,28 @@ app.get(
 );
 
 app.get(
+  "/states/history/frozen-incidence",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesFrozenIncidenceHistoryResponse();
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/history/frozen-incidence/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesFrozenIncidenceHistoryResponse(
+      parseInt(req.params.days)
+    );
+    res.json(response);
+  }
+);
+
+app.get(
   "/states/age-groups",
   queuedCache(),
   cache.route(),
@@ -358,6 +404,32 @@ app.get(
   cache.route(),
   async function (req, res) {
     const response = await StatesWeekIncidenceHistoryResponse(
+      parseInt(req.params.days),
+      req.params.state
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/:state/history/frozen-incidence",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesFrozenIncidenceHistoryResponse(
+      null,
+      req.params.state
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/:state/history/frozen-incidence/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesFrozenIncidenceHistoryResponse(
       parseInt(req.params.days),
       req.params.state
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,6 +156,45 @@ export function getStateNameByAbbreviation(
   }
 }
 
+export function getStateIdByName(name: string): number | null {
+  switch (name) {
+    case "Baden-Württemberg":
+      return 8;
+    case "Bayern":
+      return 9;
+    case "Berlin":
+      return 11;
+    case "Brandenburg":
+      return 12;
+    case "Bremen":
+      return 4;
+    case "Hamburg":
+      return 2;
+    case "Hessen":
+      return 6;
+    case "Mecklenburg-Vorpommern":
+      return 13;
+    case "Niedersachsen":
+      return 3;
+    case "Nordrhein-Westfalen":
+      return 5;
+    case "Rheinland-Pfalz":
+      return 7;
+    case "Saarland":
+      return 10;
+    case "Sachsen":
+      return 14;
+    case "Sachsen-Anhalt":
+      return 15;
+    case "Schleswig-Holstein":
+      return 1;
+    case "Thüringen":
+      return 16;
+    default:
+      return null;
+  }
+}
+
 export function getDateBefore(days: number): string {
   let offsetDate = new Date();
   offsetDate.setHours(0, 0, 0, 0);


### PR DESCRIPTION
add frozen-incidence to germany and states.
/germany/history/frozen-incidence
/germany/history/frozen-incidence/:days
/states/history/frozen-incidence
/states/history/frozen-incidence/:days
/states/:state/history/frozen-incidence
/states/:state/history/frozen-incidence/:days

 i also add a constant and a little positioning fix to the legend-map ( the yStartPosition should not be `1000 - 2 * border` but `1000- border - (hight of the rects) `! thats not realy a big thing ................

Fix #327 