### PR TITLE
Add hospitalization history

### DIFF
--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -631,5 +631,50 @@ Returns the number of recovered people in germany for the last `:days` days.
 ### Response
 
 ```json
-{}
+{
+  "data": [
+    {
+      "cases7Days": 6207,
+      "incidence7Days": 7.46,
+      "date": "2021-11-13T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 6103,
+      "incidence7Days": 7.34,
+      "date": "2021-11-14T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 6060,
+      "incidence7Days": 7.29,
+      "date": "2021-11-15T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 5888,
+      "incidence7Days": 7.08,
+      "date": "2021-11-16T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 5606,
+      "incidence7Days": 6.74,
+      "date": "2021-11-17T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 5116,
+      "incidence7Days": 6.15,
+      "date": "2021-11-18T00:00:00.000Z"
+    },
+    {
+      "cases7Days": 4437,
+      "incidence7Days": 5.34,
+      "date": "2021-11-19T00:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2021-11-19T03:01:47.000Z",
+    "lastCheckedForUpdate": "2021-11-19T15:34:49.633Z"
+  }
+}
 ```

--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -612,3 +612,24 @@ Returns the number of recovered people in germany for the last `:days` days.
   }
 }
 ```
+
+## `/germany/history/hospitalization`
+
+## `/germany/history/hospitalization/:days`
+
+### Request
+
+`GET https://api.corona-zahlen.org/germany/history/hospitalization/7`
+[Open](/germany/history/hospitalization/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |
+
+### Response
+
+```json
+{}
+```

--- a/docs/endpoints/states.md
+++ b/docs/endpoints/states.md
@@ -178,6 +178,10 @@ Redirects to `/states/history/cases`
 
 ## `/states/history/recovered/:days`
 
+## `/states/history/hospitalization`
+
+## `/states/history/hospitalization/:days`
+
 ## `/states/age-groups`
 
 ### Request
@@ -296,6 +300,10 @@ Redirects to `/states/history/cases`
 ## `/states/:state/history/recovered`
 
 ## `/states/:state/history/recovered/:days`
+
+## `/states/:state/history/hospitalization`
+
+## `/states/:state/history/hospitalization/:days`
 
 ## `/states/:state/age-groups`
 

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -199,23 +199,28 @@ export async function GermanyHospitalizationHistoryResponse(
 ): Promise<
   GermanyHistoryData<{ cases7Days: number; incidence7Days: number; date: Date }>
 > {
+  if (days != null && isNaN(days)) {
+    throw new TypeError(
+      "Wrong format for ':days' parameter! This is not a number."
+    );
+  }
   const hospitalizationData = await getHospitalizationData();
   const history = [];
-  let historyKeys = Object.keys(hospitalizationData.data);
+  let dateKeys = Object.keys(hospitalizationData.data);
   if (days != undefined) {
     const reference_date = new Date(getDateBefore(days));
-    historyKeys = historyKeys.filter((date) => new Date(date) > reference_date);
+    dateKeys = dateKeys.filter((date) => new Date(date) > reference_date);
   }
-  historyKeys.sort((a, b) => {
+  dateKeys.sort((a, b) => {
     const dateA = new Date(a);
     const dateB = new Date(b);
     return dateA.getTime() - dateB.getTime();
   });
-  historyKeys.forEach((key) => {
+  dateKeys.forEach((dateKey) => {
     history.push({
-      cases7Days: hospitalizationData.data[key].cases7Days,
-      incidence7Days: hospitalizationData.data[key].incidence7Days,
-      date: new Date(key),
+      cases7Days: hospitalizationData.data[dateKey].cases7Days,
+      incidence7Days: hospitalizationData.data[dateKey].incidence7Days,
+      date: new Date(dateKey),
     });
   });
 

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -16,8 +16,11 @@ import {
   AddDaysToDate,
   getDayDifference,
   getStateAbbreviationById,
+  getStateAbbreviationByName,
   getStateIdByAbbreviation,
+  getStateIdByName,
   getStateNameByAbbreviation,
+  getDateBefore,
 } from "../utils";
 import { ResponseData } from "../data-requests/response-data";
 import {
@@ -417,6 +420,90 @@ export async function StatesRecoveredHistoryResponse(
   return {
     data,
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
+  };
+}
+// : Promise<StatesHospitalizationHistory>
+interface StatesHospitalizationHistory {
+  [key: string]: StateHistory<{
+    cases7Days: number;
+    incidence7Days: number;
+    date: Date;
+    meta: ResponseMeta;
+  }>;
+}
+export async function StatesHospitalizationHistoryResponse(
+  days?: number,
+  p_abbreviation?: string
+): Promise<{ data: {}; meta: ResponseMeta }> {
+  if (days != null && isNaN(days)) {
+    throw new TypeError(
+      "Wrong format for ':days' parameter! This is not a number."
+    );
+  }
+  const hospitalizationData = await getHospitalizationData();
+  let dateKeys = Object.keys(hospitalizationData.data);
+  if (days) {
+    const reference_date = new Date(getDateBefore(days));
+    dateKeys = dateKeys.filter((date) => new Date(date) > reference_date);
+  }
+  dateKeys.sort((a, b) => {
+    const dateA = new Date(a);
+    const dateB = new Date(b);
+    return dateA.getTime() - dateB.getTime();
+  });
+  const historyData = {};
+  let abbreviationList = [];
+  for (let id = 1; id <= 16; id++) {
+    abbreviationList[id - 1] = getStateAbbreviationById(id);
+  }
+  dateKeys.forEach((dateKey) => {
+    const stateNameKeys = Object.keys(hospitalizationData.data[dateKey].states);
+    if (!p_abbreviation) {
+      stateNameKeys.forEach((stateName) => {
+        const id = getStateIdByName(stateName);
+        const abbreviation = getStateAbbreviationByName(stateName);
+        if (!historyData[abbreviation]) {
+          historyData[abbreviation] = {
+            id: id,
+            name: stateName,
+            history: [],
+          };
+        }
+        historyData[abbreviation].history.push({
+          cases7Days:
+            hospitalizationData.data[dateKey].states[stateName].cases7Days,
+          incidence7Days:
+            hospitalizationData.data[dateKey].states[stateName].incidence7Days,
+          date: new Date(dateKey),
+        });
+      });
+    } else if (abbreviationList.includes(p_abbreviation)) {
+      const id = getStateIdByAbbreviation(p_abbreviation);
+      const stateName = getStateNameByAbbreviation(p_abbreviation);
+      if (!historyData[p_abbreviation]) {
+        historyData[p_abbreviation] = {
+          id: id,
+          name: stateName,
+          history: [],
+        };
+      }
+      historyData[p_abbreviation].history.push({
+        cases7Days:
+          hospitalizationData.data[dateKey].states[stateName].cases7Days,
+        incidence7Days:
+          hospitalizationData.data[dateKey].states[stateName].incidence7Days,
+        date: new Date(dateKey),
+      });
+    } else {
+      throw new Error(
+        `Abbreviation ${p_abbreviation} is not allowed. Please choose one of: ${abbreviationList}`
+      );
+    }
+  });
+
+  return {
+    data: historyData,
+    meta: new ResponseMeta(hospitalizationData.lastUpdate),
   };
 }
 

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -422,19 +422,28 @@ export async function StatesRecoveredHistoryResponse(
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
   };
 }
-// : Promise<StatesHospitalizationHistory>
+
 interface StatesHospitalizationHistory {
-  [key: string]: StateHistory<{
-    cases7Days: number;
-    incidence7Days: number;
-    date: Date;
-    meta: ResponseMeta;
-  }>;
+  data: {
+    [abbreviation: string]: {
+      id: number;
+      name: string;
+      history: [
+        {
+          cases7Days: number;
+          incidence7Days: number;
+          date: Date;
+        }
+      ];
+    };
+  };
+  meta: ResponseMeta;
 }
+
 export async function StatesHospitalizationHistoryResponse(
   days?: number,
   p_abbreviation?: string
-): Promise<{ data: {}; meta: ResponseMeta }> {
+): Promise<StatesHospitalizationHistory> {
   if (days != null && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import {
   StatesWeekIncidenceHistoryResponse,
   StatesAgeGroupsResponse,
   StatesFrozenIncidenceHistoryResponse,
+  StatesHospitalizationHistoryResponse,
 } from "./responses/states";
 import {
   GermanyAgeGroupsResponse,
@@ -362,6 +363,28 @@ app.get(
 );
 
 app.get(
+  "/states/history/hospitalization",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesHospitalizationHistoryResponse();
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/history/hospitalization/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesHospitalizationHistoryResponse(
+      parseInt(req.params.days)
+    );
+    res.json(response);
+  }
+);
+
+app.get(
   "/states/age-groups",
   queuedCache(),
   cache.route(),
@@ -502,6 +525,32 @@ app.get(
   cache.route(),
   async function (req, res) {
     const response = await StatesRecoveredHistoryResponse(
+      parseInt(req.params.days),
+      req.params.state
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/:state/history/hospitalization",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesHospitalizationHistoryResponse(
+      null,
+      req.params.state
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/states/:state/history/hospitalization/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await StatesHospitalizationHistoryResponse(
       parseInt(req.params.days),
       req.params.state
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import {
   GermanyResponse,
   GermanyWeekIncidenceHistoryResponse,
   GermanyFrozenIncidenceHistoryResponse,
+  GermanyHospitalizationHistoryResponse,
 } from "./responses/germany";
 import {
   DistrictsCasesHistoryResponse,
@@ -203,6 +204,28 @@ app.get(
   cache.route(),
   async function (req, res) {
     const response = await GermanyRecoveredHistoryResponse(
+      parseInt(req.params.days)
+    );
+    res.json(response);
+  }
+);
+
+app.get(
+  "/germany/history/hospitalization",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await GermanyHospitalizationHistoryResponse();
+    res.json(response);
+  }
+);
+
+app.get(
+  "/germany/history/hospitalization/:days",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await GermanyHospitalizationHistoryResponse(
       parseInt(req.params.days)
     );
     res.json(response);


### PR DESCRIPTION
add hospitalization history to /germany and /states
/germany/history/hospitalization
/germany/history/hospitalization/:days
/states/history/hospitalization
/states/history/hospitalization/:days
/states/:state/hospitalization
/staes/:state/hospitalization/:days

cases7Days and incidence7Days are outputted! If wished age-groups can be added.

Fix #300 