### PR TITLE
add palette and userpalette

### DIFF
--- a/docs/endpoints/maps.md
+++ b/docs/endpoints/maps.md
@@ -13,9 +13,38 @@ Returns a Heatmap (PNG) of week incidences for districts.
 `GET https://api.corona-zahlen.org/map/districts`
 [Open](/map/districts)
 
+** All map links can be extended with the following parameters **
+
+| Parameter               | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| ?palette=default        | use the default palette (colors/ranges since 2021-11-12) is the same as without |
+| ?palette=old            | use the old default palette (bevor 2021-11-12)                                  |
+| ?palette=rki            | use rki palette (colors/ranges like the rki on their webside use)               |
+| ?userpalette=0,0,...... | use a userpalette example and rules below                                       |
+
+this is a example userpalette witch must be given after ?userpalette=
+
+0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
+
+witch meens the following
+
+| Stringpart            | >min | <=max    | Color  | Remark or Rule                                                          |
+| --------------------- | ---- | -------- | ------ | ----------------------------------------------------------------------- |
+| 0,0,CDCDCD;           | 0    | 0        | CDCDCD | special range min=max=0 can be used but this is not a must!             |
+| 0,5,FFFCCC;           | 0    | 5        | FFFCCC | first range must start with min=0                                       |
+| 5,25,FFF380;          | 5    | 25       | FFF380 | min next range must be max last range                                   |
+| 25,50,FFB534;         | 25   | 50       | FFB534 | hex values for color must be 6 gigit without prefix, upper or lowercase |
+| 50,100,D43624;        | 50   | 100      | D43624 |                                                                         |
+| 100,250,951214;       | 100  | 250      | 951214 |                                                                         |
+| 250,500,671212;       | 250  | 500      | 671212 |                                                                         |
+| 500,1000,DD0085;      | 500  | 1000     | DD0085 |                                                                         |
+| 1000,Infinity,7A0077; | 1000 | Infinity | 7A0077 | last range max must be "Infinity".                                      |
+
+every range needs 3 values (min, max, color) separated by , and terminated by ; after the last range the ; is a option!
+
 ### Response
 
-<img alt="districts map" src="https://api.corona-zahlen.org/map/districts" width="300">
+<img alt="districts map" src="https://api.corona-zahlen.org/map/districts?palette=default" width="300">
 
 ## `/map/districts-legend`
 
@@ -23,12 +52,12 @@ Returns a Heatmap (PNG) of week incidences for districts with a legend and headl
 
 ### Request
 
-`GET https://api.corona-zahlen.org/map/districts-legend`
-[Open](/map/districts-legend)
+`GET https://api.corona-zahlen.org/map/districts-legend?palette=rki`
+[Open](/map/districts-legend?palette=rki)
 
 ### Response
 
-<img alt="districts legend map" src="https://api.corona-zahlen.org/map/districts-legend" width="300">
+<img alt="districts legend map" src="https://api.corona-zahlen.org/map/districts-legend?palette=rki" width="300">
 
 ## `/map/districts/legend`
 
@@ -36,8 +65,8 @@ Returns the incident ranges for the colors.
 
 ### Request
 
-`GET https://api.corona-zahlen.org/map/districts/legend`
-[Open](/map/districts/legend)
+`GET https://api.corona-zahlen.org/map/districts/legend?palette=default`
+[Open](/map/districts/legend?palette=default)
 
 ### Response
 
@@ -46,18 +75,24 @@ Returns the incident ranges for the colors.
   "incidentRanges": [
     {
       "min": 0,
+      "max": 0,
+      "color": "#E2E2E2",
+      "label": "keine Fälle übermittelt"
+    },
+    {
+      "min": 0,
       "max": 1,
-      "color": "#2D81B8"
+      "color": "#25BA94"
     },
     {
       "min": 1,
-      "max": 5,
-      "color": "#7FD38D"
+      "max": 15,
+      "color": "#76D985"
     },
     {
       "min": 15,
       "max": 25,
-      "color": "#FEFFB1"
+      "color": "#FFFFA8"
     },
     {
       "min": 25,
@@ -67,35 +102,45 @@ Returns the incident ranges for the colors.
     {
       "min": 35,
       "max": 50,
-      "color": "#F08A4B"
+      "color": "#F1894A"
     },
     {
       "min": 50,
       "max": 100,
-      "color": "#EB1A1D"
+      "color": "#F21620"
     },
     {
       "min": 100,
       "max": 200,
-      "color": "#AB1316"
+      "color": "#A9141A"
     },
     {
       "min": 200,
       "max": 350,
-      "color": "#B374DD"
+      "color": "#B275DD"
     },
     {
       "min": 350,
       "max": 500,
-      "color": "#5B189B"
+      "color": "#5D179B"
     },
     {
       "min": 500,
       "max": 1000,
-      "color": "#543D35"
+      "color": "#17179B"
     },
     {
       "min": 1000,
+      "max": 1500,
+      "color": "#68463B"
+    },
+    {
+      "min": 1500,
+      "max": 2500,
+      "color": "#6D6D6D"
+    },
+    {
+      "min": 2500,
       "max": null,
       "color": "#020003"
     }
@@ -109,12 +154,12 @@ Returns a Heatmap (PNG) of week incidences for states.
 
 ### Request
 
-`GET https://api.corona-zahlen.org/map/states`
-[Open](/map/states)
+`GET https://api.corona-zahlen.org/map/states?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077`
+[Open](/map/states?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077)
 
 ### Response
 
-<img alt="states map" src="https://api.corona-zahlen.org/map/states" width="300">
+<img alt="states map" src="https://api.corona-zahlen.org/map/states?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077" width="300">
 
 ## `/map/states-legend`
 
@@ -135,8 +180,8 @@ Returns the incident ranges for the colors.
 
 ### Request
 
-`GET https://api.corona-zahlen.org/map/states/legend`
-[Open](/map/states/legend)
+`GET https://api.corona-zahlen.org/map/states/legend?palette=rki`
+[Open](/map/states/legend?palette=rki)
 
 ### Response
 
@@ -145,58 +190,49 @@ Returns the incident ranges for the colors.
   "incidentRanges": [
     {
       "min": 0,
-      "max": 1,
-      "color": "#2D81B8"
+      "max": 0,
+      "color": "#CDCDCD",
+      "label": "keine Fälle übermittelt"
     },
     {
-      "min": 1,
+      "min": 0,
       "max": 5,
-      "color": "#7FD38D"
+      "color": "#FFFCCC"
     },
     {
-      "min": 15,
+      "min": 5,
       "max": 25,
-      "color": "#FEFFB1"
+      "color": "#FFF380"
     },
     {
       "min": 25,
-      "max": 35,
-      "color": "#FECA81"
-    },
-    {
-      "min": 35,
       "max": 50,
-      "color": "#F08A4B"
+      "color": "#FFB534"
     },
     {
       "min": 50,
       "max": 100,
-      "color": "#EB1A1D"
+      "color": "#D43624"
     },
     {
       "min": 100,
-      "max": 200,
-      "color": "#AB1316"
+      "max": 250,
+      "color": "#951214"
     },
     {
-      "min": 200,
-      "max": 350,
-      "color": "#B374DD"
-    },
-    {
-      "min": 350,
+      "min": 250,
       "max": 500,
-      "color": "#5B189B"
+      "color": "#671212"
     },
     {
       "min": 500,
       "max": 1000,
-      "color": "#543D35"
+      "color": "#DD0085"
     },
     {
       "min": 1000,
       "max": null,
-      "color": "#020003"
+      "color": "#7A0077"
     }
   ]
 }

--- a/docs/endpoints/maps.md
+++ b/docs/endpoints/maps.md
@@ -22,25 +22,32 @@ Returns a Heatmap (PNG) of week incidences for districts.
 | ?palette=rki            | use rki palette (colors/ranges like the rki on their webside use)               |
 | ?userpalette=0,0,...... | use a userpalette example and rules below                                       |
 
-this is a example userpalette witch must be given after ?userpalette=
+A example userpalette witch must be given after ?userpalette= as follows:
+0,0,CDCDCD,ein test;0,5,FFFCCC;5,25,FFF380,test2;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
 
-0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
+witch meens the following:
 
-witch meens the following
+| Stringpart            | >min | <=max    | Color  | Label                                                             |
+| --------------------- | ---- | -------- | ------ | ----------------------------------------------------------------- |
+| 0,0,CDCDCD,ein test;  | 0    | 0        | CDCDCD | instead of "> 0 - 0" the text "ein test" is printed in the legend |
+| 0,5,FFFCCC;           | 0    | 5        | FFFCCC |                                                                   |
+| 5,25,FFF380,test2;    | 5    | 25       | FFF380 | instead of "> 5 - 25" the text "text2" is printed in the legend   |
+| 25,50,FFB534;         | 25   | 50       | FFB534 |                                                                   |
+| 50,100,D43624;        | 50   | 100      | D43624 |                                                                   |
+| 100,250,951214;       | 100  | 250      | 951214 |                                                                   |
+| 250,500,671212;       | 250  | 500      | 671212 |                                                                   |
+| 500,1000,DD0085;      | 500  | 1000     | DD0085 |                                                                   |
+| 1000,Infinity,7A0077; | 1000 | Infinity | 7A0077 |                                                                   |
 
-| Stringpart            | >min | <=max    | Color  | Remark or Rule                                                          |
-| --------------------- | ---- | -------- | ------ | ----------------------------------------------------------------------- |
-| 0,0,CDCDCD;           | 0    | 0        | CDCDCD | special range min=max=0 can be used but this is not a must!             |
-| 0,5,FFFCCC;           | 0    | 5        | FFFCCC | first range must start with min=0                                       |
-| 5,25,FFF380;          | 5    | 25       | FFF380 | min next range must be max last range                                   |
-| 25,50,FFB534;         | 25   | 50       | FFB534 | hex values for color must be 6 gigit without prefix, upper or lowercase |
-| 50,100,D43624;        | 50   | 100      | D43624 |                                                                         |
-| 100,250,951214;       | 100  | 250      | 951214 |                                                                         |
-| 250,500,671212;       | 250  | 500      | 671212 |                                                                         |
-| 500,1000,DD0085;      | 500  | 1000     | DD0085 |                                                                         |
-| 1000,Infinity,7A0077; | 1000 | Infinity | 7A0077 | last range max must be "Infinity".                                      |
+Rules:
 
-every range needs 3 values (min, max, color) separated by , and terminated by ; after the last range the ; is a option!
+- every range needs 3 or as option 4 values (min, max, color, option: label)
+  separated by , and terminated by ; after the last range the ; is a option, at the beginning too.
+- special range min = max = 0 can be used but this is not a must! but ....
+- first range must start with min = 0.
+- min next range must be max last range.
+- hex values for color must be 6 gigit without prefix, upper or lowercase or mixed (e.g. "0f1a3D").
+- last range max must be "Infinity" upper- or lowercase, or mixed. (e.g. "infinity" or "InFiNiTy").
 
 ### Response
 
@@ -154,8 +161,8 @@ Returns a Heatmap (PNG) of week incidences for states.
 
 ### Request
 
-`GET https://api.corona-zahlen.org/map/states?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077`
-[Open](/map/states?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077)
+`GET https://api.corona-zahlen.org/map/states`
+[Open](/map/states)
 
 ### Response
 
@@ -242,6 +249,13 @@ Returns the incident ranges for the colors.
 
 Returns a Heatmap (PNG) of hospitalization incidences for states.
 
+| Parameter               | Description                                                      |
+| ----------------------- | ---------------------------------------------------------------- |
+| ?palette=default        | use the default palette, thats the same as without               |
+| ?palette=grey           | use a grayscale palette                                          |
+| ?palette=greenred       | use a palette which runs from green (0) to red (> 15)            |
+| ?userpalette=0,0,...... | use a userpalette, example and rules at the top of this document |
+
 ### Request
 
 `GET https://api.corona-zahlen.org/map/states/hospitalization`
@@ -263,3 +277,66 @@ Returns a Heatmap (PNG) of hospitalization incidences for states with a legend a
 ### Response
 
 <img alt="states legend map" src="https://api.corona-zahlen.org/map/states-legend/hospitalization" width="300">
+
+## `/map/states/hospitalization/legend`
+
+Returns the incident ranges for the colors.
+
+### Request
+
+`GET https://api.corona-zahlen.org/map/states/hospitalization/legend`
+[Open](/map/states/hospitalization/legend)
+
+### Response
+
+```json
+{
+  "incidentRanges": [
+    {
+      "min": 0,
+      "max": 0,
+      "color": "#E2E2E2",
+      "label": "keine Fälle übermittelt"
+    },
+    {
+      "min": 0,
+      "max": 1,
+      "color": "#FCF9CA"
+    },
+    {
+      "min": 1,
+      "max": 3,
+      "color": "#FFDA9C",
+      "label": "> 1 - 3: keine einheitl. Regeln"
+    },
+    {
+      "min": 3,
+      "max": 6,
+      "color": "#F7785B",
+      "label": "> 3 - 6: 2G-Regel"
+    },
+    {
+      "min": 6,
+      "max": 9,
+      "color": "#FF3A25",
+      "label": "> 6 - 9: 2G-Plus-Regel"
+    },
+    {
+      "min": 9,
+      "max": 12,
+      "color": "#D80182",
+      "label": "> 9 - 12: > 9 weitere Maßnah."
+    },
+    {
+      "min": 12,
+      "max": 15,
+      "color": "#770175"
+    },
+    {
+      "min": 15,
+      "max": null,
+      "color": "#000000"
+    }
+  ]
+}
+```

--- a/src/configuration/colors.ts
+++ b/src/configuration/colors.ts
@@ -44,7 +44,7 @@ export class ColorRange {
 }
 
 interface weekIncidenceColorRanges {
-  [paletteType: string]: {
+  [type: string]: {
     [palette: string]: ColorRange[];
   };
 }
@@ -416,6 +416,12 @@ function BuildUserPalette(
   let userRanges = [];
   let userRange = [];
   ranges.forEach((range, index) => {
+    //define variables for parameters
+    let max: number;
+    let min: number;
+    let color: string;
+    let label: string;
+
     userRange[index] = range.split(","); // split the range into single parameters
 
     // errorchecks:
@@ -446,38 +452,36 @@ function BuildUserPalette(
         } überprüfen.`
       );
     } else if (userRange[index][1].trim().toLowerCase() == "infinity") {
-      var max: number = Infinity;
+      max = Infinity;
     } else {
-      var min = parseInt(userRange[index][0]);
+      min = parseInt(userRange[index][0]);
       max = parseInt(userRange[index][1]);
     }
 
     // first range min must be "0" if not throw a error
     if (index == 0 && min != 0) {
       throw new Error(
-        `Fehler im ${index + 1}.Bereich. ${
-          index + 1
-        }.Bereich.min muss "0" sein! ${ranges[index]} überprüfen.`
+        `1.Bereich.min muss "0" sein (IST: ${min})! ${ranges[index]} überprüfen.`
       );
     }
 
     // dont allow min > max -> throw error
     if (min > max) {
       throw new Error(
-        `Fehler im ${index + 1}.Bereich. ${index + 1}.Bereich.min > ${
+        `Fehler im ${index + 1}.Bereich. ${index + 1}.Bereich.min (${min})> ${
           index + 1
-        }.Bereich.max. ${ranges[index]} überprüfen.`
+        }.Bereich.max (${max}). ${ranges[index]} überprüfen.`
       );
     }
 
     // after first range check if range.min = range-1.max
     if (index > 0 && min != parseInt(userRange[index - 1][1])) {
       throw new Error(
-        `Fehler im ${index + 1}.Bereich. ${
+        `${
           index + 1
-        }.Bereich.min != ${index}.Bereich.max! ${ranges[index]} oder ${
-          ranges[index - 1]
-        }`
+        }.Bereich.min (IST: ${min}) != ${index}.Bereich.max (IST: ${parseInt(
+          userRange[index - 1][1]
+        )})! ${ranges[index]} oder ${ranges[index - 1]} überprüfen.`
       );
     }
 
@@ -488,12 +492,14 @@ function BuildUserPalette(
       throw new Error(
         `Fehler im ${
           index + 1
-        }.Bereich. Der dritte Wert muss eine 6 stellige Hexadezimale Zahl ohne Prefix enthalten. z.B. "FFFD000". ${
-          ranges[index]
-        } überprüfen.`
+        }.Bereich. Der dritte Wert muss eine 6 stellige Hexadezimale Zahl ohne Prefix enthalten. z.B. "FFFD00" (IST: ${userRange[
+          index
+        ][2]
+          .toUpperCase()
+          .replace(/ /g, "")}). ${ranges[index]} überprüfen.`
       );
     } else {
-      var color: string = `#${userRange[index][2]}`;
+      color = `#${userRange[index][2]}`;
     }
     // all checks passed, now write the Objects to userRanges array
 
@@ -501,7 +507,7 @@ function BuildUserPalette(
     if (userRange[index].length == 4 && userRange[index][3].trim() != "") {
       // check if this is the first range and range.min = range.max = 0 witch meens thats a
       // fixed range for value "0" and write special Object with comparefunction and label
-      const label: string = userRange[index][3].trim();
+      label = userRange[index][3].trim();
       if (index == 0 && min == 0 && max == 0) {
         userRanges.push({
           min: min,

--- a/src/configuration/colors.ts
+++ b/src/configuration/colors.ts
@@ -43,77 +43,227 @@ export class ColorRange {
   }
 }
 
-export const weekIncidenceColorRanges: ColorRange[] = [
-  new ColorRange({
-    min: 0,
-    max: 0,
-    color: "#E2E2E2",
-    compareFn: (value: number, range: ColorRange) => value === range.min,
-    label: "keine Fälle übermittelt",
-  }),
-  new ColorRange({
-    min: 0,
-    max: 1,
-    color: "#25BA94",
-  }),
-  new ColorRange({
-    min: 1,
-    max: 15,
-    color: "#76D985",
-  }),
-  new ColorRange({
-    min: 15,
-    max: 25,
-    color: "#FFFFA8",
-  }),
-  new ColorRange({
-    min: 25,
-    max: 35,
-    color: "#FECA81",
-  }),
-  new ColorRange({
-    min: 35,
-    max: 50,
-    color: "#F1894A",
-  }),
-  new ColorRange({
-    min: 50,
-    max: 100,
-    color: "#F21620",
-  }),
-  new ColorRange({
-    min: 100,
-    max: 200,
-    color: "#A9141A",
-  }),
-  new ColorRange({
-    min: 200,
-    max: 350,
-    color: "#B275DD",
-  }),
-  new ColorRange({
-    min: 350,
-    max: 500,
-    color: "#5D179B",
-  }),
-  new ColorRange({
-    min: 500,
-    max: 1000,
-    color: "#17179B",
-  }),
-  new ColorRange({
-    min: 1000,
-    max: 1500,
-    color: "#68463B",
-  }),
-  new ColorRange({
-    min: 1500,
-    max: 2500,
-    color: "#6D6D6D",
-  }),
-  new ColorRange({
-    min: 2500,
-    max: Infinity,
-    color: "#020003",
-  }),
-];
+interface weekIncidenceColorRanges {
+  [palette: string]: ColorRange[];
+}
+
+export const weekIncidenceColorRanges: weekIncidenceColorRanges = {
+  default: [
+    new ColorRange({
+      min: 0,
+      max: 0,
+      color: "#E2E2E2",
+      compareFn: (value: number, range: ColorRange) => value === range.min,
+      label: "keine Fälle übermittelt",
+    }),
+    new ColorRange({ min: 0, max: 1, color: "#25BA94" }),
+    new ColorRange({ min: 1, max: 15, color: "#76D985" }),
+    new ColorRange({ min: 15, max: 25, color: "#FFFFA8" }),
+    new ColorRange({ min: 25, max: 35, color: "#FECA81" }),
+    new ColorRange({ min: 35, max: 50, color: "#F1894A" }),
+    new ColorRange({ min: 50, max: 100, color: "#F21620" }),
+    new ColorRange({ min: 100, max: 200, color: "#A9141A" }),
+    new ColorRange({ min: 200, max: 350, color: "#B275DD" }),
+    new ColorRange({ min: 350, max: 500, color: "#5D179B" }),
+    new ColorRange({ min: 500, max: 1000, color: "#17179B" }),
+    new ColorRange({ min: 1000, max: 1500, color: "#68463B" }),
+    new ColorRange({ min: 1500, max: 2500, color: "#6D6D6D" }),
+    new ColorRange({ min: 2500, max: Infinity, color: "#020003" }),
+  ],
+  old: [
+    new ColorRange({
+      min: 0,
+      max: 0,
+      color: "#CDCDCD",
+      compareFn: (value: number, range: ColorRange) => value === range.min,
+      label: "keine Fälle übermittelt",
+    }),
+    new ColorRange({ min: 0, max: 1, color: "#3BEB47" }),
+    new ColorRange({ min: 1, max: 15, color: "#7FD38D" }),
+    new ColorRange({ min: 15, max: 25, color: "#FEFFB1" }),
+    new ColorRange({ min: 25, max: 35, color: "#FECA81" }),
+    new ColorRange({ min: 35, max: 50, color: "#F08A4B" }),
+    new ColorRange({ min: 50, max: 100, color: "#EB1A1D" }),
+    new ColorRange({ min: 100, max: 200, color: "#AB1316" }),
+    new ColorRange({ min: 200, max: 350, color: "#B374DD" }),
+    new ColorRange({ min: 350, max: 500, color: "#5B189B" }),
+    new ColorRange({ min: 500, max: 1000, color: "#543D35" }),
+    new ColorRange({ min: 1000, max: Infinity, color: "#020003" }),
+  ],
+  rki: [
+    new ColorRange({
+      min: 0,
+      max: 0,
+      color: "#CDCDCD",
+      compareFn: (value: number, range: ColorRange) => value === range.min,
+      label: "keine Fälle übermittelt",
+    }),
+    new ColorRange({ min: 0, max: 5, color: "#FFFCCC" }),
+    new ColorRange({ min: 5, max: 25, color: "#FFF380" }),
+    new ColorRange({ min: 25, max: 50, color: "#FFB534" }),
+    new ColorRange({ min: 50, max: 100, color: "#D43624" }),
+    new ColorRange({ min: 100, max: 250, color: "#951214" }),
+    new ColorRange({ min: 250, max: 500, color: "#671212" }),
+    new ColorRange({ min: 500, max: 1000, color: "#DD0085" }),
+    new ColorRange({ min: 1000, max: Infinity, color: "#7A0077" }),
+  ],
+};
+
+// example string for user palette (thats a copy of the rki palette)
+// 0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
+//min,max,color;min,max,color; ........... ;min,Infinity,color; if a semicolon at the end is a option
+
+// this function is called by GetCheckedPalette, input: userPaletteString given from ?userpalette= ,example above, build
+// a valid userpalette and append this to weekIncidenceColorRanges
+// output: the name of the userPalette (always "user")
+function BuildUserPalette(userPaletteString: string): string {
+  //if a semicolon at the end of userPaletteString, remove it
+  if (userPaletteString.substring(0, userPaletteString.length - 1) == ";") {
+    userPaletteString = userPaletteString.substring(
+      0,
+      userPaletteString.length - 1
+    );
+  }
+  const ranges = userPaletteString.split(";"); // split the string in ranges
+  const countRanges = ranges.length; // number of ranges
+  // first check, ranges.length must be >=3 and <=15 sein, if not throw a error
+  if (countRanges < 3 || countRanges > 15) {
+    throw new Error(
+      `Anzahl der Bereiche! Soll: ">=3 <=15". Ist: "${countRanges}". ${userPaletteString} überprüfen`
+    );
+  }
+  let userRanges = [];
+  let userRange = [];
+  ranges.forEach((range) => {
+    const z = ranges.indexOf(range); // rangenumber
+    userRange[z] = range.split(","); // split the range into parameters
+    // some errorchecks
+    // every range needs 3 elements if not throw a error
+    if (userRange[z].length != 3) {
+      throw new Error(
+        `Fehler im ${z + 1}.Bereich. Jeder Bereich muss 3 Werte enthalten! ${
+          ranges[z]
+        } überprüfen.`
+      );
+    }
+    // first range min must be "0" if not throw a error
+    if (z == 0 && parseInt(userRange[z][0]) != 0) {
+      throw new Error(
+        `Fehler im ${z + 1}.Bereich. ${z + 1}.Bereich.min muss "0" sein! ${
+          ranges[z]
+        } überprüfen.`
+      );
+    }
+    // dont allow min > max -> throw error
+    if (parseInt(userRange[z][0]) > parseInt(userRange[z][1])) {
+      throw new Error(
+        `Fehler im ${z + 1}.Bereich. ${z + 1}.Bereich.min > ${
+          z + 1
+        }.Bereich.max. ${ranges[z]} überprüfen.`
+      );
+    }
+    // first and second element must be an number, or first a number and second "Infinity" for last range.
+    // if this is not the last range it will be filtered out in one of the next tests
+    if (
+      isNaN(parseInt(userRange[z][0])) ||
+      (isNaN(parseInt(userRange[z][1])) && userRange[z][1] != "Infinity")
+    ) {
+      throw new Error(
+        `Fehler im ${
+          z + 1
+        }.Bereich. Die ersten beiden Werte müssen Zahlen oder "Infinity" im 2.Wert enthalten! ${
+          ranges[z]
+        } überprüfen.`
+      );
+    }
+    // third element must be 6 digit hex, bevor test, remove all spaces (if available)
+    // and convert to upper case
+    userRange[z][2] = userRange[z][2].toUpperCase().replace(/ /g, "");
+    if (!userRange[z][2].match(/^[0-9A-F]{6}$/)) {
+      throw new Error(
+        `Fehler im ${
+          z + 1
+        }.Bereich. Der dritte Wert muss eine 6 stellige Hexadezimale Zahl ohne Prefix enthalten. z.B. "FFFD000". ${
+          ranges[z]
+        } überprüfen.`
+      );
+    }
+    // after first range check if range.min = range-1.max
+    if (z != 0 && parseInt(userRange[z][0]) != parseInt(userRange[z - 1][1])) {
+      throw new Error(
+        `Fehler im ${z + 1}.Bereich. ${
+          z + 1
+        }.Bereich.min != ${z}.Bereich.max! ${ranges[z]} oder ${ranges[z - 1]}`
+      );
+    }
+    // all checks passed, now write the Objects to userRanges array
+
+    // first check if this is the first range and range.min = range.max = 0 witch meens thats a
+    // fixed range for value "0" and write special Object with comparefunction and label
+    if (
+      z == 0 &&
+      parseInt(userRange[z][0]) == 0 &&
+      parseInt(userRange[z][1]) == 0
+    ) {
+      userRanges.push({
+        min: parseInt(userRange[z][0]),
+        max: parseInt(userRange[z][1]),
+        color: "#" + userRange[z][2],
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      });
+    } else if (userRange[z][1] == "Infinity") {
+      // "Infinity" marks last range, write specal object
+      userRanges.push({
+        min: parseInt(userRange[z][0]),
+        max: Infinity,
+        color: "#" + userRange[z][2],
+      });
+    } else {
+      // all others write "normal" objects
+      userRanges.push({
+        min: parseInt(userRange[z][0]),
+        max: parseInt(userRange[z][1]),
+        color: "#" + userRange[z][2],
+      });
+    }
+  });
+  //create user palette Object and write to other hard coded palettes
+  weekIncidenceColorRanges["user"] = userRanges.map((range) => {
+    return new ColorRange(range);
+  });
+  // return name of the user palette
+  return "user";
+}
+// this function is called by function GetCheckedPalette input: a palette string from req given by ?palette=
+// output: checked palette
+function CheckParmPalette(palette: string): string {
+  const palettes = Object.keys(weekIncidenceColorRanges);
+  if (palettes.includes(palette)) {
+    return palette;
+  } else {
+    throw new Error(
+      `Falscher Parameter '?palette=${palette}' ! ${palette} existiert nicht. Gültig ist nur eine aus: ${palettes}`
+    );
+  }
+}
+
+//this function is called by server.ts /map links, needs the req, returns a valid palette
+export function GetCheckedPalette(req): string {
+  // first check if both possible parameters are given -> Error not allowed
+  if (req.query.userpalette != undefined && req.query.palette != undefined) {
+    throw new Error(
+      "Die Parameter 'palette=' und 'userpalette=' dürfen nicht zusammen angegeben werden!"
+    );
+  }
+  // set palette to 'default', will be changed if a parameter is given
+  let checkedPalette = "default";
+  // if parameter userpalette= is given build user palette, function returns new palette name
+  if (req.query.userpalette != undefined) {
+    checkedPalette = BuildUserPalette(req.query.userpalette.toString());
+  } else if (req.query.palette != undefined) {
+    // if parameter palette= is given check if the hard coded palette exists, function returns palette name!
+    checkedPalette = CheckParmPalette(req.query.palette.toString());
+  }
+  return checkedPalette;
+}

--- a/src/configuration/colors.ts
+++ b/src/configuration/colors.ts
@@ -43,122 +43,551 @@ export class ColorRange {
   }
 }
 
-export const weekIncidenceColorRanges: ColorRange[] = [
-  new ColorRange({
-    min: 0,
-    max: 0,
-    color: "#E2E2E2",
-    compareFn: (value: number, range: ColorRange) => value === range.min,
-    label: "keine Fälle übermittelt",
-  }),
-  new ColorRange({
-    min: 0,
-    max: 1,
-    color: "#25BA94",
-  }),
-  new ColorRange({
-    min: 1,
-    max: 15,
-    color: "#76D985",
-  }),
-  new ColorRange({
-    min: 15,
-    max: 25,
-    color: "#FFFFA8",
-  }),
-  new ColorRange({
-    min: 25,
-    max: 35,
-    color: "#FECA81",
-  }),
-  new ColorRange({
-    min: 35,
-    max: 50,
-    color: "#F1894A",
-  }),
-  new ColorRange({
-    min: 50,
-    max: 100,
-    color: "#F21620",
-  }),
-  new ColorRange({
-    min: 100,
-    max: 200,
-    color: "#A9141A",
-  }),
-  new ColorRange({
-    min: 200,
-    max: 350,
-    color: "#B275DD",
-  }),
-  new ColorRange({
-    min: 350,
-    max: 500,
-    color: "#5D179B",
-  }),
-  new ColorRange({
-    min: 500,
-    max: 1000,
-    color: "#17179B",
-  }),
-  new ColorRange({
-    min: 1000,
-    max: 1500,
-    color: "#68463B",
-  }),
-  new ColorRange({
-    min: 1500,
-    max: 2500,
-    color: "#6D6D6D",
-  }),
-  new ColorRange({
-    min: 2500,
-    max: Infinity,
-    color: "#020003",
-  }),
-];
+interface weekIncidenceColorRanges {
+  [type: string]: {
+    [palette: string]: ColorRange[];
+  };
+}
 
-export const hospitalizationIncidenceColorRanges: ColorRange[] = [
-  new ColorRange({
-    min: 0,
-    max: 0,
-    color: "#E2E2E2",
-    compareFn: (value: number, range: ColorRange) => value === range.min,
-    label: "keine Fälle übermittelt",
-  }),
-  new ColorRange({
-    min: 0,
-    max: 1,
-    color: "#FCF9CA",
-  }),
-  new ColorRange({
-    min: 1,
-    max: 3,
-    color: "#FFDA9C",
-  }),
-  new ColorRange({
-    min: 3,
-    max: 6,
-    color: "#F7785B",
-  }),
-  new ColorRange({
-    min: 6,
-    max: 9,
-    color: "#FF3A25",
-  }),
-  new ColorRange({
-    min: 9,
-    max: 12,
-    color: "#D80182",
-  }),
-  new ColorRange({
-    min: 12,
-    max: 15,
-    color: "#770175",
-  }),
-  new ColorRange({
-    min: 15,
-    max: Infinity,
-    color: "#000000",
-  }),
-];
+export const weekIncidenceColorRanges: weekIncidenceColorRanges = {
+  incidenceMap: {
+    default: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#E2E2E2",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 1,
+        color: "#25BA94",
+      }),
+      new ColorRange({
+        min: 1,
+        max: 15,
+        color: "#76D985",
+      }),
+      new ColorRange({
+        min: 15,
+        max: 25,
+        color: "#FFFFA8",
+      }),
+      new ColorRange({
+        min: 25,
+        max: 35,
+        color: "#FECA81",
+      }),
+      new ColorRange({
+        min: 35,
+        max: 50,
+        color: "#F1894A",
+      }),
+      new ColorRange({
+        min: 50,
+        max: 100,
+        color: "#F21620",
+      }),
+      new ColorRange({
+        min: 100,
+        max: 200,
+        color: "#A9141A",
+      }),
+      new ColorRange({
+        min: 200,
+        max: 350,
+        color: "#B275DD",
+      }),
+      new ColorRange({
+        min: 350,
+        max: 500,
+        color: "#5D179B",
+      }),
+      new ColorRange({
+        min: 500,
+        max: 1000,
+        color: "#17179B",
+      }),
+      new ColorRange({
+        min: 1000,
+        max: 1500,
+        color: "#68463B",
+      }),
+      new ColorRange({
+        min: 1500,
+        max: 2500,
+        color: "#6D6D6D",
+      }),
+      new ColorRange({
+        min: 2500,
+        max: Infinity,
+        color: "#020003",
+      }),
+    ],
+    old: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#CDCDCD",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 1,
+        color: "#3BEB47",
+      }),
+      new ColorRange({
+        min: 1,
+        max: 15,
+        color: "#7FD38D",
+      }),
+      new ColorRange({
+        min: 15,
+        max: 25,
+        color: "#FEFFB1",
+      }),
+      new ColorRange({
+        min: 25,
+        max: 35,
+        color: "#FECA81",
+      }),
+      new ColorRange({
+        min: 35,
+        max: 50,
+        color: "#F08A4B",
+      }),
+      new ColorRange({
+        min: 50,
+        max: 100,
+        color: "#EB1A1D",
+      }),
+      new ColorRange({
+        min: 100,
+        max: 200,
+        color: "#AB1316",
+      }),
+      new ColorRange({
+        min: 200,
+        max: 350,
+        color: "#B374DD",
+      }),
+      new ColorRange({
+        min: 350,
+        max: 500,
+        color: "#5B189B",
+      }),
+      new ColorRange({
+        min: 500,
+        max: 1000,
+        color: "#543D35",
+      }),
+      new ColorRange({
+        min: 1000,
+        max: Infinity,
+        color: "#020003",
+      }),
+    ],
+    rki: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#CDCDCD",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 5,
+        color: "#FFFCCC",
+      }),
+      new ColorRange({
+        min: 5,
+        max: 25,
+        color: "#FFF380",
+      }),
+      new ColorRange({
+        min: 25,
+        max: 50,
+        color: "#FFB534",
+      }),
+      new ColorRange({
+        min: 50,
+        max: 100,
+        color: "#D43624",
+      }),
+      new ColorRange({
+        min: 100,
+        max: 250,
+        color: "#951214",
+      }),
+      new ColorRange({
+        min: 250,
+        max: 500,
+        color: "#671212",
+      }),
+      new ColorRange({
+        min: 500,
+        max: 1000,
+        color: "#DD0085",
+      }),
+      new ColorRange({
+        min: 1000,
+        max: Infinity,
+        color: "#7A0077",
+      }),
+    ],
+  },
+  hospitalizationMap: {
+    default: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#E2E2E2",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 1,
+        color: "#FCF9CA",
+      }),
+      new ColorRange({
+        min: 1,
+        max: 3,
+        color: "#FFDA9C",
+        label: "> 1 - 3: keine einheitl. Regeln",
+      }),
+      new ColorRange({
+        min: 3,
+        max: 6,
+        color: "#F7785B",
+        label: "> 3 - 6: 2G-Regel",
+      }),
+      new ColorRange({
+        min: 6,
+        max: 9,
+        color: "#FF3A25",
+        label: "> 6 - 9: 2G-Plus-Regel",
+      }),
+      new ColorRange({
+        min: 9,
+        max: 12,
+        color: "#D80182",
+        label: "> 9 - 12: > 9 weitere Maßnah.",
+      }),
+      new ColorRange({
+        min: 12,
+        max: 15,
+        color: "#770175",
+      }),
+      new ColorRange({
+        min: 15,
+        max: Infinity,
+        color: "#000000",
+      }),
+    ],
+    grey: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#F0F0F0",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 1,
+        color: "#E1E1E1",
+      }),
+      new ColorRange({
+        min: 1,
+        max: 3,
+        color: "#BEBEBE",
+        label: "> 1 - 3: keine einheitl. Regeln",
+      }),
+      new ColorRange({
+        min: 3,
+        max: 6,
+        color: "#9B9B9B",
+        label: "> 3 - 6: 2G-Regel",
+      }),
+      new ColorRange({
+        min: 6,
+        max: 9,
+        color: "#787878",
+        label: "> 6 - 9: 2G-Plus-Regel",
+      }),
+      new ColorRange({
+        min: 9,
+        max: 12,
+        color: "#555555",
+        label: "> 9 - 12: > 9 weitere Maßnah.",
+      }),
+      new ColorRange({
+        min: 12,
+        max: 15,
+        color: "#323232",
+      }),
+      new ColorRange({
+        min: 15,
+        max: Infinity,
+        color: "#0F0F0F",
+      }),
+    ],
+    greenred: [
+      new ColorRange({
+        min: 0,
+        max: 0,
+        color: "#046010",
+        compareFn: (value: number, range: ColorRange) => value === range.min,
+        label: "keine Fälle übermittelt",
+      }),
+      new ColorRange({
+        min: 0,
+        max: 1,
+        color: "#28520E",
+      }),
+      new ColorRange({
+        min: 1,
+        max: 3,
+        color: "#4C450B",
+        label: "> 1 - 3: keine einheitl. Regeln",
+      }),
+      new ColorRange({
+        min: 3,
+        max: 6,
+        color: "#703709",
+        label: "> 3 - 6: 2G-Regel",
+      }),
+      new ColorRange({
+        min: 6,
+        max: 9,
+        color: "#932907",
+        label: "> 6 - 9: 2G-Plus-Regel",
+      }),
+      new ColorRange({
+        min: 9,
+        max: 12,
+        color: "#B71B05",
+        label: "> 9 - 12: > 9 weitere Maßnah.",
+      }),
+      new ColorRange({
+        min: 12,
+        max: 15,
+        color: "#DB0E02",
+      }),
+      new ColorRange({
+        min: 15,
+        max: Infinity,
+        color: "#FF0000",
+      }),
+    ],
+  },
+};
+
+// example string for user palette (thats a copy of the rki palette)
+// 0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
+//min,max,color,label?;min,max,color,label?; ........... ;min,Infinity,color,label?; a semicolon at the end is a option
+
+function BuildUserPalette(
+  paletteType: string,
+  paletteStr: string
+): { paletteType: string; palette: string } {
+  //remove a semicolon at the end and/or beginning of paletteString if available
+  if (paletteStr.substring(paletteStr.length - 1, paletteStr.length) == ";") {
+    paletteStr = paletteStr.substring(0, paletteStr.length - 1);
+  }
+  if (paletteStr.substring(0, 1) == ";") {
+    paletteStr = paletteStr.substring(1, paletteStr.length);
+  }
+
+  const ranges = paletteStr.split(";"); // split the string in ranges
+  const countRanges = ranges.length; // number of ranges
+
+  // first check, ranges.length must be >=3 and <=15 sein, if not throw a error
+  if (countRanges < 3 || countRanges > 15) {
+    throw new Error(
+      `Anzahl der Bereiche! Soll: ">=3 <=15". Ist: "${countRanges}". ${paletteStr} überprüfen`
+    );
+  }
+
+  let userRanges = [];
+  let userRange = [];
+  ranges.forEach((range, index) => {
+    userRange[index] = range.split(","); // split the range into single parameters
+
+    // errorchecks:
+
+    // every range needs 3 or 4 elements if not throw a error
+    if (userRange[index].length != 3 && userRange[index].length != 4) {
+      throw new Error(
+        `Fehler im ${
+          index + 1
+        }.Bereich. Jeder Bereich muss 3 oder 4 Werte enthalten! "${
+          ranges[index]
+        }" überprüfen.`
+      );
+    }
+
+    // first and second element must be an number, or first a number and second "Infinity" for last range.
+    // if this is not the last range it will be filtered out in one of the next tests
+    if (
+      isNaN(parseInt(userRange[index][0])) ||
+      (isNaN(parseInt(userRange[index][1])) &&
+        userRange[index][1].trim().toLowerCase() != "infinity")
+    ) {
+      throw new Error(
+        `Fehler im ${
+          index + 1
+        }.Bereich. Die ersten beiden Werte müssen Zahlen oder "Infinity" im 2.Wert enthalten! ${
+          ranges[index]
+        } überprüfen.`
+      );
+    } else if (userRange[index][1].trim().toLowerCase() == "infinity") {
+      var max: number = Infinity;
+    } else {
+      var min = parseInt(userRange[index][0]);
+      max = parseInt(userRange[index][1]);
+    }
+
+    // first range min must be "0" if not throw a error
+    if (index == 0 && min != 0) {
+      throw new Error(
+        `Fehler im ${index + 1}.Bereich. ${
+          index + 1
+        }.Bereich.min muss "0" sein! ${ranges[index]} überprüfen.`
+      );
+    }
+
+    // dont allow min > max -> throw error
+    if (min > max) {
+      throw new Error(
+        `Fehler im ${index + 1}.Bereich. ${index + 1}.Bereich.min > ${
+          index + 1
+        }.Bereich.max. ${ranges[index]} überprüfen.`
+      );
+    }
+
+    // after first range check if range.min = range-1.max
+    if (index > 0 && min != parseInt(userRange[index - 1][1])) {
+      throw new Error(
+        `Fehler im ${index + 1}.Bereich. ${
+          index + 1
+        }.Bereich.min != ${index}.Bereich.max! ${ranges[index]} oder ${
+          ranges[index - 1]
+        }`
+      );
+    }
+
+    // third element must be 6 digit hex, bevor test, remove all spaces (if available)
+    // and convert to upper case
+    userRange[index][2] = userRange[index][2].toUpperCase().replace(/ /g, "");
+    if (!userRange[index][2].match(/^[0-9A-F]{6}$/)) {
+      throw new Error(
+        `Fehler im ${
+          index + 1
+        }.Bereich. Der dritte Wert muss eine 6 stellige Hexadezimale Zahl ohne Prefix enthalten. z.B. "FFFD000". ${
+          ranges[index]
+        } überprüfen.`
+      );
+    } else {
+      var color: string = `#${userRange[index][2]}`;
+    }
+    // all checks passed, now write the Objects to userRanges array
+
+    // if a label is given and not empty it must be pushed too
+    if (userRange[index].length == 4 && userRange[index][3].trim() != "") {
+      // check if this is the first range and range.min = range.max = 0 witch meens thats a
+      // fixed range for value "0" and write special Object with comparefunction and label
+      const label: string = userRange[index][3].trim();
+      if (index == 0 && min == 0 && max == 0) {
+        userRanges.push({
+          min: min,
+          max: max,
+          color: color,
+          compareFn: (value: number, range: ColorRange) => value === range.min,
+          label: label,
+        });
+      } else {
+        // all others write "normal" objects with label
+        userRanges.push({
+          min: min,
+          max: max,
+          color: color,
+          label: label,
+        });
+      }
+    } else {
+      // check if this is the first range and range.min = range.max = 0 witch meens thats a
+      // fixed range for value "0" and write special Object with comparefunction and standart label
+      if (index == 0 && min == 0 && max == 0) {
+        userRanges.push({
+          min: min,
+          max: max,
+          color: color,
+          compareFn: (value: number, range: ColorRange) => value === range.min,
+          label: "keine Fälle übermittelt",
+        });
+      } else {
+        // all others write "normal" objects without label
+        userRanges.push({
+          min: min,
+          max: max,
+          color: color,
+        });
+      }
+    }
+  });
+
+  //create user palette Object and write to other hard coded palettes
+  weekIncidenceColorRanges[paletteType]["user"] = userRanges.map((range) => {
+    return new ColorRange(range);
+  });
+
+  // return object with paletteType and palette; palette is always "user"!
+  return { paletteType: paletteType, palette: "user" };
+}
+
+function CheckParmPalette(
+  paletteType: string,
+  palette: string
+): { paletteType: string; palette: string } {
+  const palettes = Object.keys(weekIncidenceColorRanges[paletteType]);
+  if (palettes.includes(palette)) {
+    return { paletteType: paletteType, palette: palette };
+  } else {
+    throw new Error(
+      `Falscher Parameter '?palette=${palette}' ! ${palette} existiert nicht, oder ist für den typ: ${paletteType} nicht vorgesehen. Gültig ist nur eine aus: ${palettes}`
+    );
+  }
+}
+
+export function GetCheckedPalette(
+  req,
+  paletteType: string
+): { paletteType: string; palette: string } {
+  // first check if both possible parameters are given -> Error not allowed
+  if (req.query.userpalette && req.query.palette) {
+    throw new Error(
+      "Die Parameter 'palette=' und 'userpalette=' dürfen nicht zusammen angegeben werden!"
+    );
+  }
+  // set palette to 'default', will be changed if a parameter is given
+  let checkedPalette = { paletteType: paletteType, palette: "default" };
+  // if parameter userpalette= is given build user palette, function returns new palette name
+  if (req.query.userpalette) {
+    checkedPalette = BuildUserPalette(
+      paletteType,
+      req.query.userpalette.toString()
+    );
+  } else if (req.query.palette) {
+    // if parameter palette= is given check if the hard coded palette exists, function returns palette name!
+    checkedPalette = CheckParmPalette(
+      paletteType,
+      req.query.palette.toString()
+    );
+  }
+  return checkedPalette;
+}

--- a/src/configuration/colors.ts
+++ b/src/configuration/colors.ts
@@ -44,7 +44,7 @@ export class ColorRange {
 }
 
 interface weekIncidenceColorRanges {
-  [type: string]: {
+  [paletteType: string]: {
     [palette: string]: ColorRange[];
   };
 }

--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -6,7 +6,7 @@ import { getStatesData } from "../data-requests/states";
 import { ColorRange, weekIncidenceColorRanges } from "../configuration/colors";
 import sharp from "sharp";
 
-export async function DistrictsMapResponse() {
+export async function DistrictsMapResponse(palette: string) {
   const mapData = DistrictsMap;
 
   const districtsData = await getDistrictsData();
@@ -24,8 +24,10 @@ export async function DistrictsMapResponse() {
     const district = districtsDataHashMap[id];
     const weekIncidence =
       (district.casesPerWeek / district.population) * 100000;
-    districtPathElement.attributes["fill"] =
-      getColorForWeekIncidence(weekIncidence);
+    districtPathElement.attributes["fill"] = getColorForWeekIncidence(
+      weekIncidence,
+      palette
+    );
   }
 
   const svgBuffer = Buffer.from(stringify(mapData));
@@ -33,7 +35,7 @@ export async function DistrictsMapResponse() {
   return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
-export async function DistrictsLegendMapResponse() {
+export async function DistrictsLegendMapResponse(palette: string) {
   const mapData = DistrictsMap;
 
   const districtsData = await getDistrictsData();
@@ -51,8 +53,10 @@ export async function DistrictsLegendMapResponse() {
     const district = districtsDataHashMap[id];
     const weekIncidence =
       (district.casesPerWeek / district.population) * 100000;
-    districtPathElement.attributes["fill"] =
-      getColorForWeekIncidence(weekIncidence);
+    districtPathElement.attributes["fill"] = getColorForWeekIncidence(
+      weekIncidence,
+      palette
+    );
   }
 
   const svgBuffer = Buffer.from(stringify(mapData));
@@ -61,7 +65,7 @@ export async function DistrictsLegendMapResponse() {
     getMapBackground(
       "7-Tage-Inzidenz der Landkreise",
       districtsData.lastUpdate,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[palette]
     )
   )
     .composite([{ input: svgBuffer, top: 100, left: 180 }])
@@ -69,7 +73,7 @@ export async function DistrictsLegendMapResponse() {
     .toBuffer();
 }
 
-export async function StatesMapResponse() {
+export async function StatesMapResponse(palette: string) {
   const mapData = StatesMap;
 
   const statesData = await getStatesData();
@@ -87,8 +91,10 @@ export async function StatesMapResponse() {
     const district = statesDataHashMap[id];
     const weekIncidence =
       (district.casesPerWeek / district.population) * 100000;
-    statePathElement.attributes["fill"] =
-      getColorForWeekIncidence(weekIncidence);
+    statePathElement.attributes["fill"] = getColorForWeekIncidence(
+      weekIncidence,
+      palette
+    );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
   }
@@ -98,7 +104,7 @@ export async function StatesMapResponse() {
   return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
-export async function StatesLegendMapResponse() {
+export async function StatesLegendMapResponse(palette: string) {
   const mapData = StatesMap;
 
   const statesData = await getStatesData();
@@ -116,8 +122,10 @@ export async function StatesLegendMapResponse() {
     const district = statesDataHashMap[id];
     const weekIncidence =
       (district.casesPerWeek / district.population) * 100000;
-    statePathElement.attributes["fill"] =
-      getColorForWeekIncidence(weekIncidence);
+    statePathElement.attributes["fill"] = getColorForWeekIncidence(
+      weekIncidence,
+      palette
+    );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
   }
@@ -128,7 +136,7 @@ export async function StatesLegendMapResponse() {
     getMapBackground(
       "7-Tage-Inzidenz der Bundesländer",
       statesData.lastUpdate,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[palette]
     )
   )
     .composite([{ input: svgBuffer, top: 100, left: 180 }])
@@ -136,14 +144,17 @@ export async function StatesLegendMapResponse() {
     .toBuffer();
 }
 
-export function IncidenceColorsResponse() {
+export function IncidenceColorsResponse(palette: string) {
   return {
-    incidentRanges: weekIncidenceColorRanges,
+    incidentRanges: weekIncidenceColorRanges[palette],
   };
 }
 
-function getColorForWeekIncidence(weekIncidence: number): string {
-  for (const range of weekIncidenceColorRanges) {
+function getColorForWeekIncidence(
+  weekIncidence: number,
+  palette: string
+): string {
+  for (const range of weekIncidenceColorRanges[palette]) {
     if (range.isValueInRange(weekIncidence)) {
       return range.color;
     }
@@ -164,7 +175,7 @@ function getMapBackground(
     month: "2-digit",
     day: "2-digit",
   }); // localized lastUpdate string
-  // the first part of svg
+
   let svg = `
     <svg width="850px" height="1000px" viewBox="0 0 850 1000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -181,7 +192,7 @@ function getMapBackground(
           <g transform="translate(0, ${yStartPosition - index * 40})">
             <rect fill="${
               range.color
-            }" x="0" y="0" width="30" height="30"></rect>
+            }" x="0" y="0" width="30" height="30" rx="5" ry="5" opacity="0.98"></rect>
             <text x="48" y="20" font-family="Helvetica" font-size="16" font-weight="normal" fill="#010501">
               <tspan>${range.toString()}</tspan>
             </text>

--- a/src/responses/map.ts
+++ b/src/responses/map.ts
@@ -3,11 +3,7 @@ import DistrictsMap from "../maps/districts.json";
 import StatesMap from "../maps/states.json";
 import { getDistrictsData } from "../data-requests/districts";
 import { getStatesData } from "../data-requests/states";
-import {
-  ColorRange,
-  hospitalizationIncidenceColorRanges,
-  weekIncidenceColorRanges,
-} from "../configuration/colors";
+import { ColorRange, weekIncidenceColorRanges } from "../configuration/colors";
 import sharp from "sharp";
 import {
   getHospitalizationData,
@@ -15,7 +11,10 @@ import {
 } from "../data-requests/hospitalization";
 import { getStateAbbreviationById, getStateNameByAbbreviation } from "../utils";
 
-export async function DistrictsMapResponse(palette: string) {
+export async function DistrictsMapResponse(
+  paletteType: string,
+  palette: string
+) {
   const mapData = DistrictsMap;
 
   const districtsData = await getDistrictsData();
@@ -35,7 +34,7 @@ export async function DistrictsMapResponse(palette: string) {
       (district.casesPerWeek / district.population) * 100000;
     districtPathElement.attributes["fill"] = getColorForValue(
       weekIncidence,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
   }
 
@@ -44,7 +43,10 @@ export async function DistrictsMapResponse(palette: string) {
   return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
-export async function DistrictsLegendMapResponse(palette: string) {
+export async function DistrictsLegendMapResponse(
+  paletteType: string,
+  palette: string
+) {
   const mapData = DistrictsMap;
 
   const districtsData = await getDistrictsData();
@@ -64,7 +66,7 @@ export async function DistrictsLegendMapResponse(palette: string) {
       (district.casesPerWeek / district.population) * 100000;
     districtPathElement.attributes["fill"] = getColorForValue(
       weekIncidence,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
   }
 
@@ -74,15 +76,15 @@ export async function DistrictsLegendMapResponse(palette: string) {
     getMapBackground(
       "7-Tage-Inzidenz der Landkreise",
       districtsData.lastUpdate,
-      weekIncidenceColorRanges[palette]
+      weekIncidenceColorRanges[paletteType][palette]
     )
   )
-    .composite([{ input: svgBuffer, top: 100, left: 180 }])
+    .composite([{ input: svgBuffer, top: 100, left: 180, blend: "darken" }])
     .png({ quality: 75 })
     .toBuffer();
 }
 
-export async function StatesMapResponse(palette: string) {
+export async function StatesMapResponse(paletteType: string, palette: string) {
   const mapData = StatesMap;
 
   const statesData = await getStatesData();
@@ -102,7 +104,7 @@ export async function StatesMapResponse(palette: string) {
       (district.casesPerWeek / district.population) * 100000;
     statePathElement.attributes["fill"] = getColorForValue(
       weekIncidence,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
@@ -113,7 +115,10 @@ export async function StatesMapResponse(palette: string) {
   return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
-export async function StatesLegendMapResponse(palette: string) {
+export async function StatesLegendMapResponse(
+  paletteType: string,
+  palette: string
+) {
   const mapData = StatesMap;
 
   const statesData = await getStatesData();
@@ -133,7 +138,7 @@ export async function StatesLegendMapResponse(palette: string) {
       (district.casesPerWeek / district.population) * 100000;
     statePathElement.attributes["fill"] = getColorForValue(
       weekIncidence,
-      weekIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
@@ -145,15 +150,18 @@ export async function StatesLegendMapResponse(palette: string) {
     getMapBackground(
       "7-Tage-Inzidenz der Bundesländer",
       statesData.lastUpdate,
-      weekIncidenceColorRanges[palette]
+      weekIncidenceColorRanges[paletteType][palette]
     )
   )
-    .composite([{ input: svgBuffer, top: 100, left: 180 }])
+    .composite([{ input: svgBuffer, top: 100, left: 180, blend: "darken" }])
     .png({ quality: 75 })
     .toBuffer();
 }
 
-export async function StatesHospitalizationMapResponse() {
+export async function StatesHospitalizationMapResponse(
+  paletteType: string,
+  palette: string
+) {
   const mapData = StatesMap;
 
   const hospitalizationData = await getHospitalizationData();
@@ -173,7 +181,7 @@ export async function StatesHospitalizationMapResponse() {
 
     statePathElement.attributes["fill"] = getColorForValue(
       state.incidence7Days,
-      hospitalizationIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
@@ -184,7 +192,10 @@ export async function StatesHospitalizationMapResponse() {
   return sharp(svgBuffer).png({ quality: 75 }).toBuffer();
 }
 
-export async function StatesHospitalizationLegendMapResponse() {
+export async function StatesHospitalizationLegendMapResponse(
+  paletteType: string,
+  palette: string
+) {
   const mapData = StatesMap;
 
   const hospitalizationData = await getHospitalizationData();
@@ -204,7 +215,7 @@ export async function StatesHospitalizationLegendMapResponse() {
 
     statePathElement.attributes["fill"] = getColorForValue(
       state.incidence7Days,
-      hospitalizationIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     );
     statePathElement.attributes["stroke"] = "#DBDBDB";
     statePathElement.attributes["stroke-width"] = "0.9";
@@ -216,17 +227,17 @@ export async function StatesHospitalizationLegendMapResponse() {
     getMapBackground(
       "Hospitalisierungsinzidenz",
       hospitalizationData.lastUpdate,
-      hospitalizationIncidenceColorRanges
+      weekIncidenceColorRanges[paletteType][palette]
     )
   )
-    .composite([{ input: svgBuffer, top: 100, left: 180 }])
+    .composite([{ input: svgBuffer, top: 100, left: 180, blend: "darken" }])
     .png({ quality: 75 })
     .toBuffer();
 }
 
-export function IncidenceColorsResponse() {
+export function IncidenceColorsResponse(paletteType: string, palette: string) {
   return {
-    incidentRanges: weekIncidenceColorRanges,
+    incidentRanges: weekIncidenceColorRanges[paletteType][palette],
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import compression from "compression";
 import queue from "@marlon360/express-queue";
 import "express-async-errors";
 import axios from "axios";
-
+import { GetCheckedPalette } from "./configuration/colors";
 import {
   StatesCasesHistoryResponse,
   StatesDeathsHistoryResponse,
@@ -800,8 +800,9 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req);
     res.setHeader("Content-Type", "image/png");
-    const response = await DistrictsMapResponse();
+    const response = await DistrictsMapResponse(checkedPalette);
     res.send(response);
   }
 );
@@ -811,8 +812,9 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req);
     res.setHeader("Content-Type", "image/png");
-    const response = await DistrictsLegendMapResponse();
+    const response = await DistrictsLegendMapResponse(checkedPalette);
     res.send(response);
   }
 );
@@ -822,13 +824,15 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    res.json(IncidenceColorsResponse());
+    const checkedPalette = GetCheckedPalette(req);
+    res.json(IncidenceColorsResponse(checkedPalette));
   }
 );
 
 app.get("/map/states", queuedCache(), cache.route(), async function (req, res) {
+  const checkedPalette = GetCheckedPalette(req);
   res.setHeader("Content-Type", "image/png");
-  const response = await StatesMapResponse();
+  const response = await StatesMapResponse(checkedPalette);
   res.send(response);
 });
 
@@ -837,8 +841,9 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req);
     res.setHeader("Content-Type", "image/png");
-    const response = await StatesLegendMapResponse();
+    const response = await StatesLegendMapResponse(checkedPalette);
     res.send(response);
   }
 );
@@ -848,7 +853,8 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    res.json(IncidenceColorsResponse());
+    const checkedPalette = GetCheckedPalette(req);
+    res.json(IncidenceColorsResponse(checkedPalette));
   }
 );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -874,9 +874,12 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const checkedPalette = GetCheckedPalette(req);
+    const checkedPalette = GetCheckedPalette(req, "incidenceMap");
     res.setHeader("Content-Type", "image/png");
-    const response = await DistrictsMapResponse(checkedPalette);
+    const response = await DistrictsMapResponse(
+      checkedPalette.paletteType,
+      checkedPalette.palette
+    );
     res.send(response);
   }
 );
@@ -886,9 +889,12 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const checkedPalette = GetCheckedPalette(req);
+    const checkedPalette = GetCheckedPalette(req, "incidenceMap");
     res.setHeader("Content-Type", "image/png");
-    const response = await DistrictsLegendMapResponse(checkedPalette);
+    const response = await DistrictsLegendMapResponse(
+      checkedPalette.paletteType,
+      checkedPalette.palette
+    );
     res.send(response);
   }
 );
@@ -898,15 +904,23 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const checkedPalette = GetCheckedPalette(req);
-    res.json(IncidenceColorsResponse(checkedPalette));
+    const checkedPalette = GetCheckedPalette(req, "incidenceMap");
+    res.json(
+      IncidenceColorsResponse(
+        checkedPalette.paletteType,
+        checkedPalette.palette
+      )
+    );
   }
 );
 
 app.get("/map/states", queuedCache(), cache.route(), async function (req, res) {
-  const checkedPalette = GetCheckedPalette(req);
+  const checkedPalette = GetCheckedPalette(req, "incidenceMap");
   res.setHeader("Content-Type", "image/png");
-  const response = await StatesMapResponse(checkedPalette);
+  const response = await StatesMapResponse(
+    checkedPalette.paletteType,
+    checkedPalette.palette
+  );
   res.send(response);
 });
 
@@ -915,9 +929,12 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const checkedPalette = GetCheckedPalette(req);
+    const checkedPalette = GetCheckedPalette(req, "incidenceMap");
     res.setHeader("Content-Type", "image/png");
-    const response = await StatesLegendMapResponse(checkedPalette);
+    const response = await StatesLegendMapResponse(
+      checkedPalette.paletteType,
+      checkedPalette.palette
+    );
     res.send(response);
   }
 );
@@ -927,8 +944,13 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const checkedPalette = GetCheckedPalette(req);
-    res.json(IncidenceColorsResponse(checkedPalette));
+    const checkedPalette = GetCheckedPalette(req, "incidenceMap");
+    res.json(
+      IncidenceColorsResponse(
+        checkedPalette.paletteType,
+        checkedPalette.palette
+      )
+    );
   }
 );
 
@@ -937,8 +959,12 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req, "hospitalizationMap");
     res.setHeader("Content-Type", "image/png");
-    const response = await StatesHospitalizationLegendMapResponse();
+    const response = await StatesHospitalizationLegendMapResponse(
+      checkedPalette.paletteType,
+      checkedPalette.palette
+    );
     res.send(response);
   }
 );
@@ -948,9 +974,28 @@ app.get(
   queuedCache(),
   cache.route(),
   async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req, "hospitalizationMap");
     res.setHeader("Content-Type", "image/png");
-    const response = await StatesHospitalizationMapResponse();
+    const response = await StatesHospitalizationMapResponse(
+      checkedPalette.paletteType,
+      checkedPalette.palette
+    );
     res.send(response);
+  }
+);
+
+app.get(
+  "/map/states/hospitalization/legend",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const checkedPalette = GetCheckedPalette(req, "hospitalizationMap");
+    res.json(
+      IncidenceColorsResponse(
+        checkedPalette.paletteType,
+        checkedPalette.palette
+      )
+    );
   }
 );
 


### PR DESCRIPTION
Add the option to choose from three hard coded palletes by passing parameter ?palette= on request.
The three hard coded palettes are "default" (witch is the same as without parameter und used since 2021-11-12), "old" (the ranges and colors used bevor 2021-11-12) or "rki" (ranges and colors like the rki is useing on their dashboard.
Also add the possibility of using a userpalette with free chooseable ranges and colors, by passing a parameter ?userpalette=
example (this is the same as the default palette):
/map/districts?userpalette=0,0,CDCDCD;0,5,FFFCCC;5,25,FFF380;25,50,FFB534;50,100,D43624;100,250,951214;250,500,671212;500,1000,DD0085;1000,Infinity,7A0077;
Instuctions and rules are im doc/endpoints/maps.md.
Deviations from the rules are caught by detailed error messages.
All /map/....... links are supported. Also hospitalization maps and labels are now supported

I hope you like it............... and if not ............ just close the request. I dont have any problems with that. i had a lot of fun to write this enhancment. 