### PR TITLE
rename getFrozenIncidenceHistory to getDistrictsFrozenIncidenceHistory

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -1,14 +1,9 @@
 import axios from "axios";
 import XLSX from "xlsx";
-import {
-  getDateBefore,
-  getStateAbbreviationById,
-  getStateAbbreviationByName,
-  RKIError,
-} from "../utils";
+import { getDateBefore, getStateAbbreviationByName, RKIError } from "../utils";
 import { ResponseData } from "./response-data";
 
-export interface FrozenIncidenceData {
+export interface DistrictsFrozenIncidenceData {
   ags: string;
   name: string;
   history: {
@@ -17,10 +12,10 @@ export interface FrozenIncidenceData {
   }[];
 }
 
-export async function getFrozenIncidenceHistory(
+export async function getDistrictsFrozenIncidenceHistory(
   days?: number,
   ags?: string
-): Promise<ResponseData<FrozenIncidenceData[]>> {
+): Promise<ResponseData<DistrictsFrozenIncidenceData[]>> {
   const response = await axios.get(
     "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile",
     {

--- a/src/responses/districts.ts
+++ b/src/responses/districts.ts
@@ -17,8 +17,8 @@ import {
   getStateAbbreviationByName,
 } from "../utils";
 import {
-  FrozenIncidenceData,
-  getFrozenIncidenceHistory,
+  DistrictsFrozenIncidenceData,
+  getDistrictsFrozenIncidenceHistory,
 } from "../data-requests/frozen-incidence";
 
 interface DistrictData extends IDistrictData {
@@ -379,7 +379,7 @@ export async function DistrictsRecoveredHistoryResponse(
 
 interface FrozenIncidenceHistoryData extends IResponseMeta {
   data: {
-    [key: string]: FrozenIncidenceData;
+    [key: string]: DistrictsFrozenIncidenceData;
   };
 }
 
@@ -387,7 +387,10 @@ export async function FrozenIncidenceHistoryResponse(
   days?: number,
   ags?: string
 ): Promise<FrozenIncidenceHistoryData> {
-  const frozenIncidenceHistoryData = await getFrozenIncidenceHistory(days, ags);
+  const frozenIncidenceHistoryData = await getDistrictsFrozenIncidenceHistory(
+    days,
+    ags
+  );
 
   let data = {};
   frozenIncidenceHistoryData.data.forEach((historyData) => {


### PR DESCRIPTION
because now we have districts and states frozen-incidence history data we should rename the old getFrozenIncidenceHistory function and the associated interface.

- rename getFrozenIncidenceHistory to getDistrictsFrozenIncidenceHistory
- rename interface FrozenIncidenceData to DistrictsFrozenIncidenceData
- remove unnecessary import