### PR TITLE
fix faulty date header in frozen-incidence xlsx sheet

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -124,10 +124,15 @@ export async function getStatesFrozenIncidenceHistory(
     const dateKeys = Object.keys(states);
     // ignore the first element (witch is the state)
     dateKeys.splice(0, 1);
-    dateKeys.forEach((dateKey) => {
-      const date = new Date(
-        dateKey.toString().replace(date_pattern, "$3-$2-$1")
-      );
+    let date: Date;
+    dateKeys.forEach((dateKey, index) => {
+      date = new Date(dateKey.toString().replace(date_pattern, "$3-$2-$1"));
+      // check if date is a valid date, if not add 1 day to previus date (hopefully it is not the first datekey ....)
+      if (isNaN(date.getTime())) {
+        const pDate = new Date(dateKeys[index - 1]);
+        date = AddDaysToDate(pDate, 1);
+        dateKeys[index] = date.toISOString().split("T").shift();
+      }
       history.push({ weekIncidence: states[dateKey], date });
     });
 


### PR DESCRIPTION
This fixes the faulty date header in the newest xlsx sheet of the frozen-incidence for districts
Fix #369 