### PR TITLE
add vacciantion quotes by age, drop indication from output

### DIFF
--- a/docs/endpoints/vaccinations.md
+++ b/docs/endpoints/vaccinations.md
@@ -26,13 +26,41 @@ Hence, you may use this object to calculate the number of vaccinations on the la
 
 `delta` New first vaccination compared to yesterday
 
-`quote` Quote of first vaccinated people
+`quote` Quote of first vaccinated people (legacy)
+
+`quotes` Quotes by agegroups
+
+`quotes.total` Quote of first vaccinated people (same as `quote`)
+
+`quotes.A12-A17` Quote of first vaccinated people with age >=12 to <=17 years
+
+`quotes.A18+` Quote of first vaccinated people with agegroup >= 18 years
+
+`quotes.A18+.total` Quote of first vaccinated people with age >= 18 years
+
+`quotes.A18+.A18-A59` Quote of first vaccinated people with age >= 18 to <= 59 years
+
+`quotes.A18+.A60+` Quote of first vaccinated people with age >= 60 years
 
 `secondVaccination.vaccinated` Number of people who got the second vaccination
 
 `secondVaccination.delta` New second vaccinations compared to yesterday
 
-`secondVaccination.quote` Quote of full vaccinated people
+`secondVaccination.quote` Quote of full vaccinated people (legacy)
+
+`secondVaccination.quotes` Quotes of full vaccinated people by agegroups
+
+`secondVaccination.quotes.total` Quote of full vaccinated people (same as `secondVaccination.quote`)
+
+`secondVaccination.quotes.A12-A17` Quote of full vaccinated people with age >=12 to <=17 years
+
+`secondVaccination.quotes.A18+` Quote of full vaccinated people with agegroup >= 18 years
+
+`secondVaccination.quotes.A18+.total` Quote of full vaccinated people with age >= 18 years
+
+`secondVaccination.quotes.A18+.A18-A59` Quote of full vaccinated people with age >= 18 to <= 59 years
+
+`secondVaccination.quotes.A18+.A60+` Quote of full vaccinated people with age >= 60 years
 
 `secondVaccination.vaccination.biontech` Number of people who received their second dose of BioNTech
 
@@ -48,157 +76,260 @@ Hence, you may use this object to calculate the number of vaccinations on the la
 
 `boosterVaccination.delta` New booster vaccinations compared to yesterday
 
+`boosterVaccination.quote` Quote of boostered people (legacy)
+
+`boosterVaccination.quotes` Quotes of boostered people by agegroups
+
+`boosterVaccination.quotes.total` Quote of boostered people (same as `boosterVaccination.quote`)
+
+`boosterVaccination.quotes.A12-A17` Quote of boostered people with age >=12 to <=17 years
+
+`boosterVaccination.quotes.A18+` Quote of boostered people with agegroup >= 18 years
+
+`boosterVaccination.quotes.A18+.total` Quote of boostered people with age >= 18 years
+
+`boosterVaccination.quotes.A18+.A18-A59` Quote of boostered people with age >= 18 to <= 59 years
+
+`boosterVaccination.quotes.A18+.A60+` Quote of boostered people with age >= 60 years
+
 _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
 
 ```json
 {
-  "data": {
-    "administeredVaccinations":103814560,
-    "vaccinated":55144235,
-    "vaccination": {
-      "biontech":38539475,
-      "moderna":4420627,
-      "astraZeneca":9226749,
-      "janssen":2957384
+  "data":
+  {
+    "administeredVaccinations":152496126,
+    "vaccinated":61930498,
+    "vaccination":
+    {
+      "biontech":44139701,
+      "moderna":4942335,
+      "astraZeneca":9269166,
+      "janssen":3579296
     },
-    "delta":97944,
-    "quote":0.6629999999999999,
-    "secondVaccination": {
-      "vaccinated":51465242,
-      "vaccination": {
-        "biontech":40000635,
-        "moderna":5066122,
-        "astraZeneca":3441101
+    "delta":43404,
+    "quote":0.745,
+    "quotes":
+    {
+      "total":0.745,
+      "A12-A17":0.606,
+      "A18+":
+      {
+        "total":0.846,
+        "A18-A59":0.778,
+        "A60+":0.883
+      }
+    },
+    "secondVaccination":
+    {
+      "vaccinated":59574879,
+      "vaccination":
+      {
+        "biontech":46842638,
+        "moderna":5681616,
+        "astraZeneca":3471329
       },
-      "delta":118952,
-      "quote":0.619},
-      "boosterVaccination": {
-        "vaccinated":162467,
-        "vaccination": {
-          "biontech":152383,
-          "moderna":9534,
-          "janssen":498
-        },
-        "delta":26896
-      },
-      "latestDailyVaccinations": {
-        "date":"2021-09-09T00:00:00.000Z",
-        "vaccinated":97944,
-        "firstVaccination":97944,
-        "secondVaccination":118952,
-        "boosterVaccination":26896
-      },
-      "indication": {
-        "age":null,
-        "job":null,
-        "medical":null,
-        "nursingHome":null,
-        "secondVaccination": {
-          "age":null,
-          "job":null,
-          "medical":null,
-          "nursingHome":null
+      "delta":81268,
+      "quote":0.716,
+      "quotes":
+      {
+        "total":0.716,
+        "A12-A17":0.539,
+        "A18+":
+        {
+          "total":0.823,
+          "A18-A59":0.796,
+          "A60+":0.874
         }
+      }
+    },
+    "boosterVaccination":
+    {
+      "vaccinated":34570045,
+      "vaccination":
+      {
+        "biontech":21575727,
+        "moderna":12986294,
+        "janssen":4067
       },
-      "states": {
-        "BW": {
-          "name":"Baden-Württemberg",
-          "administeredVaccinations":13452010,
-          "vaccinated":7059693,
-          "vaccination": {
-            "biontech":4957525,
-            "moderna":548708,
-            "astraZeneca":1174218,
-            "janssen":379242
+      "delta":470517,
+      "quote":0.416,
+      "quotes":
+      {
+        "total":0.416,
+        "A12-A17":0.079,
+        "A18+":
+        {
+          "total":0.493,
+          "A18-A59":0.411,
+          "A60+":0.646
+        }
+      }
+    },
+    "latestDailyVaccinations":
+    {
+      "date":"2022-01-06T00:00:00.000Z",
+      "vaccinated":43404,
+      "firstVaccination":43404,
+      "secondVaccination":81268,
+      "boosterVaccination":470517
+    },
+    "states":
+    {
+      "BW":
+      {
+        "name":"Baden-Württemberg",
+        "administeredVaccinations":20047413,
+        "vaccinated":8000730,
+        "vaccination":
+        {
+          "biontech":5728206,
+          "moderna":617589,
+          "astraZeneca":1179235,
+          "janssen":475700
+        },
+        "delta":4041,
+        "quote":0.721,
+        "quotes":
+        {
+          "total":0.721,
+          "A12-A17":0.575,
+          "A18+":
+          {
+            "total":0.821,
+            "A18-A59":0.757,
+            "A60+":0.871
+          }
+        },
+        "secondVaccination":
+        {
+          "vaccinated":7771045,
+          "vaccination":
+          {
+            "biontech":6176357,
+            "moderna":719509,
+            "astraZeneca":399479
           },
-          "delta":12951,
-          "quote":0.636,
-          "secondVaccination": {
-            "vaccinated":6739559,
-            "vaccination": {
-              "biontech":5318060,
-              "moderna":645030,
-              "astraZeneca":397227
-            },
-            "delta":12400,
-            "quote":0.607
-          },
-          "boosterVaccination": {
-            "vaccinated":32000,
-            "vaccination": {
-              "biontech":30952,
-              "moderna":1047,
-              "janssen":1
-            },
-            "delta":4552
-          },
-          "indication": {
-            "age":null,
-            "job":null,
-            "medical":null,
-            "nursingHome":null,
-            "secondVaccination": {
-              "age":null,
-              "job":null,
-              "medical":null,
-              "nursingHome":null
+          "delta":4035,
+          "quote":0.7,
+          "quotes":
+          {
+            "total":0.7,
+            "A12-A17":0.502,
+            "A18+":
+            {
+              "total":0.808,
+              "A18-A59":0.783,
+              "A60+":0.86
             }
           }
         },
-        // ...
-        "Bund": {
-          "name":"ImpfzentrenBund",
-          "administeredVaccinations":360252,
-          "vaccinated":187858,
-          "vaccination": {
-            "biontech":80905,
-            "moderna":82127,
-            "astraZeneca":19590,
-            "janssen":5236
+        "boosterVaccination":
+        {
+          "vaccinated":4751338,
+          "vaccination":
+          {
+            "biontech":2911520,
+            "moderna":1838534,
+            "janssen":86
           },
-          "delta":123,
+          "delta":34809,
+          "quote":0.428,
+          "quotes":
+          {
+            "total":0.428,
+            "A12-A17":0.502,
+            "A18+":
+            {
+              "total":0.507,
+              "A18-A59":0.442,
+              "A60+":0.641
+            }
+          }
+        }
+      },
+      ...
+      "Bund":
+      {
+        "name":"Bundesressorts",
+        "administeredVaccinations":484493,
+        "vaccinated":200288,
+        "vaccination":
+        {
+          "biontech":88672,
+          "moderna":83224,
+          "astraZeneca":20255,
+          "janssen":8137
+        },
+        "delta":45,
+        "quote":null,
+        "quotes":
+        {
+          "total":null,
+          "A12-A17":null,
+          "A18+":
+          {
+            "total":null,
+            "A18-A59":null,
+            "A60+":null
+          }
+        },
+        "secondVaccination":
+        {
+          "vaccinated":190434,
+          "vaccination":
+          {
+            "biontech":85832,
+            "moderna":86628,
+            "astraZeneca":9837
+          },
+          "delta":145,
           "quote":null,
-          "secondVaccination": {
-            "vaccinated":177597,
-            "vaccination": {
-              "biontech":79462,
-              "moderna":84337,
-              "astraZeneca":8562
-            },
-            "delta":194,
-            "quote":null
+          "quotes":
+          {
+            "total":null,
+            "A12-A17":null,
+            "A18+":
+            {
+              "total":null,
+              "A18-A59":null,
+              "A60+":null
+            }
+          }
+        },
+        "boosterVaccination":
+        {
+          "vaccinated":101908,
+          "vaccination":
+          {
+            "biontech":74195,
+            "moderna":27695,
+            "janssen":2
           },
-          "boosterVaccination": {
-            "vaccinated":33,
-            "vaccination": {
-              "biontech":23,
-              "moderna":10,
-              "janssen":0
-            },
-            "delta":2
-          },
-          "indication": {
-            "age":null,
-            "job":null,
-            "medical":null,
-            "nursingHome":null,
-            "secondVaccination": {
-              "age":null,
-              "job":null,
-              "medical":null,
-              "nursingHome":null
+          "delta":1135,
+          "quote":null,
+          "quotes":
+          {
+            "total":null,
+            "A12-A17":null,
+            "A18+":
+            {
+              "total":null,
+              "A18-A59":null,
+              "A60+":null
             }
           }
         }
       }
-    },
-    "meta": {
-      "source":"Robert Koch-Institut",
-      "contact":"Marlon Lueckert (m.lueckert@me.com)",
-      "info":"https://github.com/marlon360/rki-covid-api",
-      "lastUpdate":"2021-09-10T08:05:30.000Z",
-      "lastCheckedForUpdate":"2021-09-12T19:05:52.074Z"
     }
+  },
+  "meta":
+  {
+    "source":"Robert Koch-Institut",
+    "contact":"Marlon Lueckert (m.lueckert@me.com)",
+    "info":"https://github.com/marlon360/rki-covid-api",
+    "lastUpdate":"2022-01-07T07:58:27.000Z",
+    "lastCheckedForUpdate":"2022-01-08T13:00:46.855Z"
   }
 }
 ```

--- a/src/data-requests/vaccination.ts
+++ b/src/data-requests/vaccination.ts
@@ -18,6 +18,16 @@ function clearEntry(entry: any) {
   }
 }
 
+interface quotes {
+  total: number;
+  "A12-A17": number;
+  "A18+": {
+    total: number;
+    "A18-A59": number;
+    "A60+": number;
+  };
+}
+
 export interface VaccinationCoverage {
   administeredVaccinations: number;
   vaccinated: number;
@@ -29,6 +39,7 @@ export interface VaccinationCoverage {
   };
   delta: number;
   quote: number;
+  quotes: quotes;
   secondVaccination: {
     vaccinated: number;
     vaccination: {
@@ -38,6 +49,7 @@ export interface VaccinationCoverage {
     };
     delta: number;
     quote: number;
+    quotes: quotes;
   };
   boosterVaccination: {
     vaccinated: number;
@@ -48,18 +60,7 @@ export interface VaccinationCoverage {
     };
     delta: number;
     quote: number;
-  };
-  indication: {
-    age: number;
-    job: number;
-    medical: number;
-    nursingHome: number;
-    secondVaccination: {
-      age: number;
-      job: number;
-      medical: number;
-      nursingHome: number;
-    };
+    quotes: quotes;
   };
   latestDailyVaccinations: VaccinationHistoryEntry;
   states: {
@@ -75,6 +76,7 @@ export interface VaccinationCoverage {
       };
       delta: number;
       quote: number;
+      quotes: quotes;
       secondVaccination: {
         vaccinated: number;
         vaccination: {
@@ -84,6 +86,7 @@ export interface VaccinationCoverage {
         };
         delta: number;
         quote: number;
+        quotes: quotes;
       };
       boosterVaccination: {
         vaccinated: number;
@@ -94,18 +97,7 @@ export interface VaccinationCoverage {
         };
         delta: number;
         quote: number;
-      };
-      indication: {
-        age: number;
-        job: number;
-        medical: number;
-        nursingHome: number;
-        secondVaccination: {
-          age: number;
-          job: number;
-          medical: number;
-          nursingHome: number;
-        };
+        quotes: quotes;
       };
     };
   };
@@ -174,50 +166,50 @@ export async function getVaccinationCoverage(): Promise<
   const quoteJson = XLSX.utils.sheet_to_json<{
     ags: number;
     state: string;
-    totalvaccination: number;
-    total1: number;
-    total1_5to11: number;
-    totalfull: number;
-    totalbooster: number;
-    quote1: number;
-    quote1_ls18: number;
-    quote1_18plus_total: number;
-    quote1_18to59: number;
-    quote1_gr60: number;
-    quotefull: number;
-    quotefull_ls18: number;
-    quotefull_18plus_total: number;
-    quotefull_18to59: number;
-    quotefull_gr60: number;
-    quoteboost: number;
-    quoteboost_ls18: number;
-    quoteboost_18plus_total: number;
-    quoteboost_18to59: number;
-    quoteboost_gr60: number;
+    vaccination: number;
+    n1st: number;
+    n1st5to11: number;
+    n2nd: number;
+    n3rd: number;
+    q1st: number;
+    q1stls18: number;
+    q1st18plus: number;
+    q1st18to59: number;
+    q1stgr60: number;
+    q2nd: number;
+    q2ndls18: number;
+    q2nd18plus: number;
+    q2nd18to59: number;
+    q2ndgr60: number;
+    q3rd: number;
+    q3rdls18: number;
+    q3rd18plus: number;
+    q3rd18to59: number;
+    q3rdgr60: number;
   }>(quoteSheet, {
     header: [
       "ags",
       "state",
-      "totalvaccination",
-      "total1",
-      "total1_5to11:",
-      "totalfull",
-      "totalbooster",
-      "quote1",
-      "quote1_ls18",
-      "quote1_18plus_total",
-      "quote1_18to59",
-      "quote1_gr60",
-      "quotefull",
-      "quotefull_ls18",
-      "quotefull_18plus_total",
-      "quotefull_18to59",
-      "quotefull_gr60",
-      "quoteboost",
-      "quoteboost_ls18",
-      "quoteboost_18plus_total",
-      "quoteboost_18to59",
-      "quoteboost_gr60",
+      "vaccination",
+      "n1st",
+      "n1st5to11:",
+      "n2nd",
+      "n3rd",
+      "q1st",
+      "q1stls18",
+      "q1st18plus",
+      "q1st18to59",
+      "q1stgr60",
+      "q2nd",
+      "q2ndls18",
+      "q2nd18plus",
+      "q2nd18to59",
+      "q2ndgr60",
+      "q3rd",
+      "q3rdls18",
+      "q3rd18plus",
+      "q3rd18to59",
+      "q3rdgr60",
     ],
     range: "A4:V21",
   });
@@ -233,6 +225,15 @@ export async function getVaccinationCoverage(): Promise<
     },
     delta: 0,
     quote: 0,
+    quotes: {
+      total: 0,
+      "A12-A17": 0,
+      "A18+": {
+        total: 0,
+        "A18-A59": 0,
+        "A60+": 0,
+      },
+    },
     secondVaccination: {
       vaccinated: 0,
       vaccination: {
@@ -242,6 +243,15 @@ export async function getVaccinationCoverage(): Promise<
       },
       delta: 0,
       quote: 0,
+      quotes: {
+        total: 0,
+        "A12-A17": 0,
+        "A18+": {
+          total: 0,
+          "A18-A59": 0,
+          "A60+": 0,
+        },
+      },
     },
     boosterVaccination: {
       vaccinated: 0,
@@ -252,6 +262,15 @@ export async function getVaccinationCoverage(): Promise<
       },
       delta: 0,
       quote: 0,
+      quotes: {
+        total: 0,
+        "A12-A17": 0,
+        "A18+": {
+          total: 0,
+          "A18-A59": 0,
+          "A60+": 0,
+        },
+      },
     },
     latestDailyVaccinations: {
       date: null,
@@ -260,30 +279,18 @@ export async function getVaccinationCoverage(): Promise<
       boosterVaccination: 0,
       vaccinated: 0,
     },
-    indication: {
-      age: null,
-      job: null,
-      medical: null,
-      nursingHome: null,
-      secondVaccination: {
-        age: null,
-        job: null,
-        medical: null,
-        nursingHome: null,
-      },
-    },
     states: {},
   };
 
   for (let i = 0; i < 18; i++) {
     const entry = json[i];
     clearEntry(entry);
-    const quoteEntry = quoteJson[i];
-    clearEntry(quoteEntry);
+    const quotes = quoteJson[i];
+    clearEntry(quotes);
 
     if (entry.state == "Gesamt") {
-      coverage.administeredVaccinations = quoteEntry.totalvaccination;
-      coverage.vaccinated = quoteEntry.total1;
+      coverage.administeredVaccinations = quotes.vaccination;
+      coverage.vaccinated = quotes.n1st;
       coverage.vaccination = {
         biontech: entry.firstBiontech,
         moderna: entry.firstModerna,
@@ -292,9 +299,27 @@ export async function getVaccinationCoverage(): Promise<
       };
       coverage.delta = entry.firstDifference;
       coverage.quote =
-        quoteEntry.quote1 === null ? null : quoteEntry.quote1 / 100.0;
+        quotes.q1st === null ? null : limitDecimals(quotes.q1st / 100.0, 3);
+      coverage.quotes.total =
+        quotes.q1st === null ? null : limitDecimals(quotes.q1st / 100.0, 3);
+      coverage.quotes["A12-A17"] =
+        quotes.q1stls18 === null
+          ? null
+          : limitDecimals(quotes.q1stls18 / 100.0, 3);
+      coverage.quotes["A18+"].total =
+        quotes.q1st18plus === null
+          ? null
+          : limitDecimals(quotes.q1st18plus / 100.0, 3);
+      coverage.quotes["A18+"]["A18-A59"] =
+        quotes.q1st18to59 === null
+          ? null
+          : limitDecimals(quotes.q1st18to59 / 100.0, 3);
+      coverage.quotes["A18+"]["A60+"] =
+        quotes.q1stgr60 === null
+          ? null
+          : limitDecimals(quotes.q1stgr60 / 100.0, 3);
       coverage.secondVaccination = {
-        vaccinated: quoteEntry.totalfull,
+        vaccinated: quotes.n2nd,
         vaccination: {
           biontech: entry.fullBiontech,
           moderna: entry.fullModerna,
@@ -302,9 +327,31 @@ export async function getVaccinationCoverage(): Promise<
         },
         delta: entry.fullDifference,
         quote:
-          quoteEntry.quotefull === null ? null : quoteEntry.quotefull / 100.0,
+          quotes.q2nd === null ? null : limitDecimals(quotes.q2nd / 100.0, 3),
+        quotes: {
+          total:
+            quotes.q2nd === null ? null : limitDecimals(quotes.q2nd / 100.0, 3),
+          "A12-A17":
+            quotes.q2ndls18 === null
+              ? null
+              : limitDecimals(quotes.q2ndls18 / 100.0, 3),
+          "A18+": {
+            total:
+              quotes.q2nd18plus === null
+                ? null
+                : limitDecimals(quotes.q2nd18plus / 100.0, 3),
+            "A18-A59":
+              quotes.q2nd18to59 === null
+                ? null
+                : limitDecimals(quotes.q2nd18to59 / 100.0, 3),
+            "A60+":
+              quotes.q2ndgr60 === null
+                ? null
+                : limitDecimals(quotes.q2ndgr60 / 100.0, 3),
+          },
+        },
       };
-      (coverage.boosterVaccination = {
+      coverage.boosterVaccination = {
         vaccinated: entry.boosterVaccination,
         vaccination: {
           biontech: entry.boosterBiontech,
@@ -313,20 +360,30 @@ export async function getVaccinationCoverage(): Promise<
         },
         delta: entry.boosterDifference,
         quote:
-          quoteEntry.quoteboost === null ? null : quoteEntry.quoteboost / 100.0,
-      }),
-        (coverage.indication = {
-          age: null,
-          job: null,
-          medical: null,
-          nursingHome: null,
-          secondVaccination: {
-            age: null,
-            job: null,
-            medical: null,
-            nursingHome: null,
+          quotes.q3rd === null ? null : limitDecimals(quotes.q3rd / 100.0, 3),
+        quotes: {
+          total:
+            quotes.q3rd === null ? null : limitDecimals(quotes.q3rd / 100.0, 3),
+          "A12-A17":
+            quotes.q3rdls18 === null
+              ? null
+              : limitDecimals(quotes.q3rdls18 / 100.0, 3),
+          "A18+": {
+            total:
+              quotes.q3rd18plus === null
+                ? null
+                : limitDecimals(quotes.q3rd18plus / 100.0, 3),
+            "A18-A59":
+              quotes.q3rd18to59 === null
+                ? null
+                : limitDecimals(quotes.q3rd18to59 / 100.0, 3),
+            "A60+":
+              quotes.q3rdgr60 === null
+                ? null
+                : limitDecimals(quotes.q3rdgr60 / 100.0, 3),
           },
-        });
+        },
+      };
     } else {
       const cleanedStateName = cleanupString(entry.state);
       // cleanedStateName should always be cleaned
@@ -335,8 +392,8 @@ export async function getVaccinationCoverage(): Promise<
         : getStateAbbreviationByName(cleanedStateName);
       coverage.states[abbreviation] = {
         name: cleanedStateName,
-        administeredVaccinations: quoteEntry.totalvaccination,
-        vaccinated: quoteEntry.total1,
+        administeredVaccinations: quotes.vaccination,
+        vaccinated: quotes.n1st,
         vaccination: {
           biontech: entry.firstBiontech,
           moderna: entry.firstModerna,
@@ -344,9 +401,32 @@ export async function getVaccinationCoverage(): Promise<
           janssen: entry.firstJanssen,
         },
         delta: entry.firstDifference,
-        quote: quoteEntry.quote1 === null ? null : quoteEntry.quote1 / 100.0,
+        quote:
+          quotes.q1st === null ? null : limitDecimals(quotes.q1st / 100.0, 3),
+        quotes: {
+          total:
+            quotes.q1st === null ? null : limitDecimals(quotes.q1st / 100.0, 3),
+          "A12-A17":
+            quotes.q1stls18 === null
+              ? null
+              : limitDecimals(quotes.q1stls18 / 100.0, 3),
+          "A18+": {
+            total:
+              quotes.q1st18plus === null
+                ? null
+                : limitDecimals(quotes.q1st18plus / 100.0, 3),
+            "A18-A59":
+              quotes.q1st18to59 === null
+                ? null
+                : limitDecimals(quotes.q1st18to59 / 100.0, 3),
+            "A60+":
+              quotes.q1stgr60 === null
+                ? null
+                : limitDecimals(quotes.q1stgr60 / 100.0, 3),
+          },
+        },
         secondVaccination: {
-          vaccinated: quoteEntry.totalfull,
+          vaccinated: quotes.n2nd,
           vaccination: {
             biontech: entry.fullBiontech,
             moderna: entry.fullModerna,
@@ -354,7 +434,31 @@ export async function getVaccinationCoverage(): Promise<
           },
           delta: entry.fullDifference,
           quote:
-            quoteEntry.quotefull === null ? null : quoteEntry.quotefull / 100.0,
+            quotes.q2nd === null ? null : limitDecimals(quotes.q2nd / 100.0, 3),
+          quotes: {
+            total:
+              quotes.q2nd === null
+                ? null
+                : limitDecimals(quotes.q2nd / 100.0, 3),
+            "A12-A17":
+              quotes.q2ndls18 === null
+                ? null
+                : limitDecimals(quotes.q2ndls18 / 100.0, 3),
+            "A18+": {
+              total:
+                quotes.q2nd18plus === null
+                  ? null
+                  : limitDecimals(quotes.q2nd18plus / 100.0, 3),
+              "A18-A59":
+                quotes.q2nd18to59 === null
+                  ? null
+                  : limitDecimals(quotes.q2nd18to59 / 100.0, 3),
+              "A60+":
+                quotes.q2ndgr60 === null
+                  ? null
+                  : limitDecimals(quotes.q2ndgr60 / 100.0, 3),
+            },
+          },
         },
         boosterVaccination: {
           vaccinated: entry.boosterVaccination,
@@ -365,20 +469,30 @@ export async function getVaccinationCoverage(): Promise<
           },
           delta: entry.boosterDifference,
           quote:
-            quoteEntry.quoteboost === null
-              ? null
-              : quoteEntry.quoteboost / 100.0,
-        },
-        indication: {
-          age: null,
-          job: null,
-          medical: null,
-          nursingHome: null,
-          secondVaccination: {
-            age: null,
-            job: null,
-            medical: null,
-            nursingHome: null,
+            quotes.q3rd === null ? null : limitDecimals(quotes.q3rd / 100.0, 3),
+          quotes: {
+            total:
+              quotes.q3rd === null
+                ? null
+                : limitDecimals(quotes.q3rd / 100.0, 3),
+            "A12-A17":
+              quotes.q3rdls18 === null
+                ? null
+                : limitDecimals(quotes.q2ndls18 / 100.0, 3),
+            "A18+": {
+              total:
+                quotes.q3rd18plus === null
+                  ? null
+                  : limitDecimals(quotes.q3rd18plus / 100.0, 3),
+              "A18-A59":
+                quotes.q3rd18to59 === null
+                  ? null
+                  : limitDecimals(quotes.q3rd18to59 / 100.0, 3),
+              "A60+":
+                quotes.q3rdgr60 === null
+                  ? null
+                  : limitDecimals(quotes.q3rdgr60 / 100.0, 3),
+            },
           },
         },
       };
@@ -394,6 +508,10 @@ export async function getVaccinationCoverage(): Promise<
     data: coverage,
     lastUpdate: lastUpdate,
   };
+}
+
+function limitDecimals(value: number, decimals: number): number {
+  return parseFloat(value.toFixed(decimals));
 }
 
 export interface VaccinationHistoryEntry {


### PR DESCRIPTION
- add vacciantion quotes by age groups
- drop indication from output (witch are not used since august)
- rename some variables to shorter names for readability 
- add a function to limit the number of decimals to prevent things like this 0,47999999999999999