### PR TITLE
bugfix use new url and format for frozen incidence XSLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-ge
 **Frozen-Incidence data**
 
 https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile
+https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_Archiv.xlsx?__blob=publicationFile
 
 **Age groups**
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Testzahlen-ge
 
 **Frozen-Incidence data**
 
-https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile
+https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile
 
 **Age groups**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ Leave a star if you like it or [open an issue](https://github.com/marlon360/rki-
 
 **Frozen-Incidence data**
 
-[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?\_\_blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile)
+[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile)
 
 **Age groups**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ Leave a star if you like it or [open an issue](https://github.com/marlon360/rki-
 
 **Frozen-Incidence data**
 
-[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile)
+[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?\_\_blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile)
 
 **Age groups**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ Leave a star if you like it or [open an issue](https://github.com/marlon360/rki-
 **Frozen-Incidence data**
 
 [https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?\_\_blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile)
+[https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_Archiv.xlsx?\_\_blob=publicationFile](https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_Archiv.xlsx?__blob=publicationFile)
 
 **Age groups**
 

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -36,31 +36,30 @@ export async function getDistrictsFrozenIncidenceHistory(
   const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
   const lastUpdate = new Date(response.headers["last-modified"]);
 
-  let districts = json
-    .map((district) => {
-      const name = district["LK"];
-      const ags = district["LKNR"].toString().padStart(5, "0");
+  let districts = json.map((district) => {
+    const name = district["LK"];
+    const ags = district["LKNR"].toString().padStart(5, "0");
 
-      let history = [];
+    let history = [];
 
-      // get all date keys
-      const dateKeys = Object.keys(district);
-      // ignore the first two elements (LK, LKNR)
-      dateKeys.splice(0, 2);
-      dateKeys.forEach((dateKey) => {
-        const date = new Date(
-          dateKey.toString().replace(date_pattern, "$3-$2-$1")
-        );
-        history.push({ weekIncidence: district[dateKey], date });
-      });
-
-      if (days != null) {
-        const reference_date = new Date(getDateBefore(days));
-        history = history.filter((element) => element.date > reference_date);
-      }
-
-      return { ags, name, history };
+    // get all date keys
+    const dateKeys = Object.keys(district);
+    // ignore the first two elements (LK, LKNR)
+    dateKeys.splice(0, 2);
+    dateKeys.forEach((dateKey) => {
+      const date = new Date(
+        dateKey.toString().replace(date_pattern, "$3-$2-$1")
+      );
+      history.push({ weekIncidence: district[dateKey], date });
     });
+
+    if (days != null) {
+      const reference_date = new Date(getDateBefore(days));
+      history = history.filter((element) => element.date > reference_date);
+    }
+
+    return { ags, name, history };
+  });
 
   if (ags != null) {
     districts = districts.filter((district) => district.ags === ags);

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -125,7 +125,7 @@ export async function getDistrictsFrozenIncidenceHistory(
     ? districts.length > 0 && districts[0].history.length > 0
     : districts.length > 0 &&
       districts[0].history.length > 0 &&
-      districts[0].history[0].date > new Date(getDateBefore(days));
+      districts[0].history[0].date > new Date(getDateBefore(days - 1));
 
   if (fetchArchiveData) {
     let archiveData = await getDistrictsFrozenIncidenceHistoryArchive();
@@ -263,7 +263,7 @@ export async function getStatesFrozenIncidenceHistory(
     ? states.length > 0 && states[0].history.length > 0
     : states.length > 0 &&
       states[0].history.length > 0 &&
-      states[0].history[0].date > new Date(getDateBefore(days));
+      states[0].history[0].date > new Date(getDateBefore(days - 1));
 
   if (fetchArchiveData) {
     // load all archive data

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -112,18 +112,11 @@ export async function getDistrictsFrozenIncidenceHistory(
   }
 
   // do we need to fetch archive data as well?
-  let fetchArchiveData = false;
-  if (days === null) {
-    fetchArchiveData = districts.length > 0 && districts[0].history.length > 0; // check if we got data already;
-  } else {
-    const reference_date = new Date(getDateBefore(days));
-    if (districts.length > 0 && districts[0].history.length > 0) {
-      // check if we got data already
-      if (districts[0].history.length < days) {
-        fetchArchiveData = true;
-      }
-    }
-  }
+  const fetchArchiveData = !days
+    ? districts.length > 0 && districts[0].history.length > 0
+    : districts.length > 0 &&
+      districts[0].history.length > 0 &&
+      districts[0].history.length < days;
 
   if (fetchArchiveData) {
     let archiveData = await getDistrictsFrozenIncidenceHistoryArchive();
@@ -257,18 +250,11 @@ export async function getStatesFrozenIncidenceHistory(
   }
 
   // do we need to fetch archive data as well?
-  let fetchArchiveData = false;
-  if (days === null) {
-    fetchArchiveData = states.length > 0 && states[0].history.length > 0; // check if we got data already;
-  } else {
-    const reference_date = new Date(getDateBefore(days));
-    if (states.length > 0 && states[0].history.length > 0) {
-      // check if we got data already
-      if (states[0].history.length < days) {
-        fetchArchiveData = true;
-      }
-    }
-  }
+  const fetchArchiveData = !days
+    ? states.length > 0 && states[0].history.length > 0
+    : states.length > 0 &&
+      states[0].history.length > 0 &&
+      states[0].history.length < days;
 
   if (fetchArchiveData) {
     // load all archive data

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -17,7 +17,7 @@ export async function getDistrictsFrozenIncidenceHistory(
   ags?: string
 ): Promise<ResponseData<DistrictsFrozenIncidenceData[]>> {
   const response = await axios.get(
-    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile",
+    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile",
     {
       responseType: "arraybuffer",
     }
@@ -37,7 +37,6 @@ export async function getDistrictsFrozenIncidenceHistory(
   const lastUpdate = new Date(response.headers["last-modified"]);
 
   let districts = json
-    .filter((district) => !!district["NR"])
     .map((district) => {
       const name = district["LK"];
       const ags = district["LKNR"].toString().padStart(5, "0");
@@ -46,8 +45,8 @@ export async function getDistrictsFrozenIncidenceHistory(
 
       // get all date keys
       const dateKeys = Object.keys(district);
-      // ignore the first three elements (rowNumber, LK, LKNR)
-      dateKeys.splice(0, 3);
+      // ignore the first two elements (LK, LKNR)
+      dateKeys.splice(0, 2);
       dateKeys.forEach((dateKey) => {
         const date = new Date(
           dateKey.toString().replace(date_pattern, "$3-$2-$1")
@@ -87,7 +86,7 @@ export async function getStatesFrozenIncidenceHistory(
   abbreviation?: string
 ): Promise<ResponseData<StatesFrozenIncidenceData[]>> {
   const response = await axios.get(
-    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile",
+    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile",
     {
       responseType: "arraybuffer",
     }
@@ -106,7 +105,7 @@ export async function getStatesFrozenIncidenceHistory(
   const lastUpdate = new Date(response.headers["last-modified"]);
 
   let states = json.map((states) => {
-    const name = states["__EMPTY"]; //there is no header
+    const name = states["MeldeLandkreisBundesland"];
     const abbreviation = getStateAbbreviationByName(name);
 
     let history = [];

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -1,6 +1,11 @@
 import axios from "axios";
 import XLSX from "xlsx";
-import { getDateBefore, getStateAbbreviationByName, RKIError } from "../utils";
+import {
+  getDateBefore,
+  getStateAbbreviationByName,
+  RKIError,
+  getDateFromString,
+} from "../utils";
 import { ResponseData } from "./response-data";
 
 export interface DistrictsFrozenIncidenceData {
@@ -10,6 +15,50 @@ export interface DistrictsFrozenIncidenceData {
     date: Date;
     weekIncidence: number;
   }[];
+}
+
+async function getDistrictsFrozenIncidenceHistoryArchive(): Promise<
+  DistrictsFrozenIncidenceData[]
+> {
+  const response = await axios.get(
+    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_Archiv.xlsx?__blob=publicationFile",
+    {
+      responseType: "arraybuffer",
+    }
+  );
+  const data = response.data;
+  if (data.error) {
+    throw new RKIError(data.error, response.config.url);
+  }
+
+  var workbook = XLSX.read(data, { type: "buffer", cellDates: true });
+  const sheet = workbook.Sheets["LK_7-Tage-Inzidenz (fixiert)"];
+  // table starts in row 5 (parameter is zero indexed)
+  const json = XLSX.utils.sheet_to_json(sheet, { range: 4 });
+
+  // date is in cell A2
+  const lastUpdate = new Date(response.headers["last-modified"]);
+
+  let districts = json
+    .filter((district) => !!district["NR"])
+    .map((district) => {
+      const name = district["LK"];
+      const ags = district["LKNR"].toString().padStart(5, "0");
+
+      let history = [];
+
+      // get all date keys
+      const dateKeys = Object.keys(district);
+      // ignore the first three elements (rowNumber, LK, LKNR)
+      dateKeys.splice(0, 3);
+      dateKeys.forEach((dateKey) => {
+        const date = getDateFromString(dateKey.toString());
+        history.push({ weekIncidence: district[dateKey], date });
+      });
+
+      return { ags, name, history };
+    });
+  return districts;
 }
 
 export async function getDistrictsFrozenIncidenceHistory(
@@ -33,7 +82,6 @@ export async function getDistrictsFrozenIncidenceHistory(
   const json = XLSX.utils.sheet_to_json(sheet, { range: 4 });
 
   // date is in cell A2
-  const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
   const lastUpdate = new Date(response.headers["last-modified"]);
 
   let districts = json.map((district) => {
@@ -47,9 +95,7 @@ export async function getDistrictsFrozenIncidenceHistory(
     // ignore the first two elements (LK, LKNR)
     dateKeys.splice(0, 2);
     dateKeys.forEach((dateKey) => {
-      const date = new Date(
-        dateKey.toString().replace(date_pattern, "$3-$2-$1")
-      );
+      const date = getDateFromString(dateKey.toString());
       history.push({ weekIncidence: district[dateKey], date });
     });
 
@@ -65,6 +111,45 @@ export async function getDistrictsFrozenIncidenceHistory(
     districts = districts.filter((district) => district.ags === ags);
   }
 
+  // do we need to fetch archive data as well?
+  let fetchArchiveData = false;
+  if (days === null) {
+    fetchArchiveData = districts.length > 0 && districts[0].history.length > 0; // check if we got data already;
+  } else {
+    const reference_date = new Date(getDateBefore(days));
+    if (districts.length > 0 && districts[0].history.length > 0) {
+      // check if we got data already
+      if (districts[0].history.length < days) {
+        fetchArchiveData = true;
+      }
+    }
+  }
+
+  if (fetchArchiveData) {
+    let archiveData = await getDistrictsFrozenIncidenceHistoryArchive();
+    // filter by abbreviation
+    if (ags != null) {
+      archiveData = archiveData.filter((district) => district.ags === ags);
+    }
+    // filter by days
+    if (days != null) {
+      const reference_date = new Date(getDateBefore(days));
+      archiveData = archiveData.map((district) => {
+        district.history = district.history.filter(
+          (element) => element.date > reference_date
+        );
+        return district;
+      });
+    }
+    // merge archive data with current data
+    districts = districts.map((district) => {
+      district.history.unshift(
+        ...archiveData.find((element) => element.ags === district.ags).history
+      );
+      return district;
+    });
+  }
+
   return {
     data: districts,
     lastUpdate: lastUpdate,
@@ -78,6 +163,48 @@ export interface StatesFrozenIncidenceData {
     date: Date;
     weekIncidence: number;
   }[];
+}
+
+async function getStatesFrozenIncidenceHistoryArchive(): Promise<
+  StatesFrozenIncidenceData[]
+> {
+  const response = await axios.get(
+    "https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_Archiv.xlsx?__blob=publicationFile",
+    {
+      responseType: "arraybuffer",
+    }
+  );
+  const data = response.data;
+  if (data.error) {
+    throw new RKIError(data.error, response.config.url);
+  }
+
+  var workbook = XLSX.read(data, { type: "buffer", cellDates: true });
+  const sheet = workbook.Sheets["BL_7-Tage-Inzidenz (fixiert)"];
+  // table starts in row 5 (parameter is zero indexed)
+  const json = XLSX.utils.sheet_to_json(sheet, { range: 4 });
+
+  const lastUpdate = new Date(response.headers["last-modified"]);
+
+  let states = json.map((states) => {
+    const name = states["__EMPTY"]; //there is no header
+    const abbreviation = getStateAbbreviationByName(name);
+
+    let history = [];
+
+    // get all date keys
+    const dateKeys = Object.keys(states);
+    // ignore the first element (witch is the state)
+    dateKeys.splice(0, 1);
+    dateKeys.forEach((dateKey) => {
+      const date = getDateFromString(dateKey.toString());
+      history.push({ weekIncidence: states[dateKey], date });
+    });
+
+    return { abbreviation, name, history };
+  });
+
+  return states;
 }
 
 export async function getStatesFrozenIncidenceHistory(
@@ -100,7 +227,6 @@ export async function getStatesFrozenIncidenceHistory(
   // table starts in row 5 (parameter is zero indexed)
   const json = XLSX.utils.sheet_to_json(sheet, { range: 4 });
 
-  const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
   const lastUpdate = new Date(response.headers["last-modified"]);
 
   let states = json.map((states) => {
@@ -114,9 +240,7 @@ export async function getStatesFrozenIncidenceHistory(
     // ignore the first element (witch is the state)
     dateKeys.splice(0, 1);
     dateKeys.forEach((dateKey) => {
-      const date = new Date(
-        dateKey.toString().replace(date_pattern, "$3-$2-$1")
-      );
+      const date = getDateFromString(dateKey.toString());
       history.push({ weekIncidence: states[dateKey], date });
     });
 
@@ -130,6 +254,50 @@ export async function getStatesFrozenIncidenceHistory(
 
   if (abbreviation != null) {
     states = states.filter((states) => states.abbreviation === abbreviation);
+  }
+
+  // do we need to fetch archive data as well?
+  let fetchArchiveData = false;
+  if (days === null) {
+    fetchArchiveData = states.length > 0 && states[0].history.length > 0; // check if we got data already;
+  } else {
+    const reference_date = new Date(getDateBefore(days));
+    if (states.length > 0 && states[0].history.length > 0) {
+      // check if we got data already
+      if (states[0].history.length < days) {
+        fetchArchiveData = true;
+      }
+    }
+  }
+
+  if (fetchArchiveData) {
+    // load all archive data
+    let archiveData = await getStatesFrozenIncidenceHistoryArchive();
+    // filter by abbreviation
+    if (abbreviation != null) {
+      archiveData = archiveData.filter(
+        (state) => state.abbreviation === abbreviation
+      );
+    }
+    // filter by days
+    if (days != null) {
+      const reference_date = new Date(getDateBefore(days));
+      archiveData = archiveData.map((state) => {
+        state.history = state.history.filter(
+          (element) => element.date > reference_date
+        );
+        return state;
+      });
+    }
+    // merge archive data with current data
+    states = states.map((state) => {
+      state.history.unshift(
+        ...archiveData.find(
+          (element) => element.abbreviation === state.abbreviation
+        ).history
+      );
+      return state;
+    });
   }
 
   return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,6 +207,20 @@ export function getDayDifference(date1: Date, date2: Date): number {
   return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 }
 
+export function getDateFromString(dateString: string): Date {
+  if (dateString.indexOf("/") > -1) {
+    // probably this format: 8/25/21: m/d/y
+    const parts = dateString.split("/");
+    return new Date(
+      `20${parts[2]}-${parts[0].padStart(2, "0")}-${parts[1].padStart(2, "0")}`
+    );
+  } else {
+    // probably this format: 01.12.2020: dd.mm.yyyy
+    const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
+    return new Date(dateString.replace(date_pattern, "$3-$2-$1"));
+  }
+}
+
 export function AddDaysToDate(date: Date, days: number): Date {
   return new Date(date.getTime() + days * 1000 * 60 * 60 * 24);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,20 +207,6 @@ export function getDayDifference(date1: Date, date2: Date): number {
   return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 }
 
-export function getDateFromString(dateString: string): Date {
-  if (dateString.indexOf("/") > -1) {
-    // probably this format: 8/25/21: m/d/y
-    const parts = dateString.split("/");
-    return new Date(
-      `20${parts[2]}-${parts[0].padStart(2, "0")}-${parts[1].padStart(2, "0")}`
-    );
-  } else {
-    // probably this format: 01.12.2020: dd.mm.yyyy
-    const date_pattern = /(\d{2})\.(\d{2})\.(\d{4})/;
-    return new Date(dateString.replace(date_pattern, "$3-$2-$1"));
-  }
-}
-
 export function AddDaysToDate(date: Date, days: number): Date {
   return new Date(date.getTime() + days * 1000 * 60 * 60 * 24);
 }


### PR DESCRIPTION
The XLS file located at https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?\_\_blob=publicationFile is not available anymore.
A file with changes in data format is now available at https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab_aktuell.xlsx?__blob=publicationFile

Documentation of URLs on RKI website: https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Daten/Fallzahlen_Kum_Tab.xlsx?__blob=publicationFile

Fix #393 