### PR TITLE
add adjusted (predicted) values to hospitalisation history

### DIFF
--- a/docs/endpoints/germany.md
+++ b/docs/endpoints/germany.md
@@ -630,51 +630,149 @@ Returns the number of recovered people in germany for the last `:days` days.
 
 ### Response
 
+`cases7Days` updated number of hospitalization cases of the last 7 days.
+
+`incidence7Days` updated 7 day incidence of hospitalization.
+
+`date` publishing date of all values.
+
+Since 2021-03-09 the RKI is publisching adjusted (predicted) values for cases7Days and incidence7Days. If these values ​​are available, they are output below. These values are unavailable bevor 2021-03-09 and for the last 3 days.
+
+`fixedCases7Days` the number of 7 day cases witch is published at `date` first (fixed, that will never change!).
+
+`updatedCases7Days` the today updated number of 7 day cases and the same as `cases7Days`.
+
+`adjustedLowerCases7Days` the 95% lower limit adjusted (predicted) number of 7 day cases.
+
+`adjustedCases7Days` the adjusted (predicted) number of 7 day cases.
+
+`adjustedUpperCases7Days` the 95% upper limit adjusted (predicted) number of 7 day cases.
+
+`fixedIncidence7Days` the 7 day incidence witch is published at `date` first (fixed, that will never change!).
+
+`updatedIncidence7Days` the today updated 7 day incidence and the same as `incidence7Days`.
+
+`adjustedLowerIncidence7Days` the 95% lower limit adjusted (predicted) 7 day incidence.
+
+`adjustedIncidence7Days` the adjusted (predicted) 7 day incidence.
+
+`adjustedUpperIncidence7Days` the 95% upper limit adjusted (predicted) 7 day incidence.
+
 ```json
 {
   "data": [
     {
-      "cases7Days": 6207,
-      "incidence7Days": 7.46,
-      "date": "2021-11-13T00:00:00.000Z"
+      "cases7Days": 7629,
+      "incidence7Days": 9.17,
+      "date": "2022-02-19T00:00:00.000Z",
+      "fixedCases7Days": 5301,
+      "updatedCases7Days": 7629,
+      "adjustedLowerCases7Days": 9606,
+      "adjustedCases7Days": 9840,
+      "adjustedUpperCases7Days": 10024,
+      "fixedIncidence7Days": 6.37,
+      "updatedIncidence7Days": 9.17,
+      "adjustedLowerIncidence7Days": 11.55,
+      "adjustedIncidence7Days": 11.83,
+      "adjustedUpperIncidence7Days": 12.06
     },
     {
-      "cases7Days": 6103,
-      "incidence7Days": 7.34,
-      "date": "2021-11-14T00:00:00.000Z"
+      "cases7Days": 7491,
+      "incidence7Days": 9.01,
+      "date": "2022-02-20T00:00:00.000Z",
+      "fixedCases7Days": 5213,
+      "updatedCases7Days": 7491,
+      "adjustedLowerCases7Days": 9634,
+      "adjustedCases7Days": 9866,
+      "adjustedUpperCases7Days": 10061,
+      "fixedIncidence7Days": 6.27,
+      "updatedIncidence7Days": 9.01,
+      "adjustedLowerIncidence7Days": 11.59,
+      "adjustedIncidence7Days": 11.87,
+      "adjustedUpperIncidence7Days": 12.1
     },
     {
-      "cases7Days": 6060,
-      "incidence7Days": 7.29,
-      "date": "2021-11-15T00:00:00.000Z"
+      "cases7Days": 7415,
+      "incidence7Days": 8.92,
+      "date": "2022-02-21T00:00:00.000Z",
+      "fixedCases7Days": 5040,
+      "updatedCases7Days": 7415,
+      "adjustedLowerCases7Days": 9705,
+      "adjustedCases7Days": 9936,
+      "adjustedUpperCases7Days": 10125,
+      "fixedIncidence7Days": 6.06,
+      "updatedIncidence7Days": 8.92,
+      "adjustedLowerIncidence7Days": 11.67,
+      "adjustedIncidence7Days": 11.95,
+      "adjustedUpperIncidence7Days": 12.18
     },
     {
-      "cases7Days": 5888,
-      "incidence7Days": 7.08,
-      "date": "2021-11-16T00:00:00.000Z"
+      "cases7Days": 7137,
+      "incidence7Days": 8.58,
+      "date": "2022-02-22T00:00:00.000Z",
+      "fixedCases7Days": 5165,
+      "updatedCases7Days": 7137,
+      "adjustedLowerCases7Days": 9764,
+      "adjustedCases7Days": 10003,
+      "adjustedUpperCases7Days": 10249,
+      "fixedIncidence7Days": 6.21,
+      "updatedIncidence7Days": 8.58,
+      "adjustedLowerIncidence7Days": 11.74,
+      "adjustedIncidence7Days": 12.03,
+      "adjustedUpperIncidence7Days": 12.33
     },
     {
-      "cases7Days": 5606,
-      "incidence7Days": 6.74,
-      "date": "2021-11-17T00:00:00.000Z"
+      "cases7Days": 6607,
+      "incidence7Days": 7.95,
+      "date": "2022-02-23T00:00:00.000Z",
+      "fixedCases7Days": 5275,
+      "updatedCases7Days": 6607,
+      "adjustedLowerCases7Days": null,
+      "adjustedCases7Days": null,
+      "adjustedUpperCases7Days": null,
+      "fixedIncidence7Days": 6.34,
+      "updatedIncidence7Days": 7.95,
+      "adjustedLowerIncidence7Days": null,
+      "adjustedIncidence7Days": null,
+      "adjustedUpperIncidence7Days": null
     },
     {
-      "cases7Days": 5116,
-      "incidence7Days": 6.15,
-      "date": "2021-11-18T00:00:00.000Z"
+      "cases7Days": 6034,
+      "incidence7Days": 7.26,
+      "date": "2022-02-24T00:00:00.000Z",
+      "fixedCases7Days": 5217,
+      "updatedCases7Days": 6034,
+      "adjustedLowerCases7Days": null,
+      "adjustedCases7Days": null,
+      "adjustedUpperCases7Days": null,
+      "fixedIncidence7Days": 6.27,
+      "updatedIncidence7Days": 7.26,
+      "adjustedLowerIncidence7Days": null,
+      "adjustedIncidence7Days": null,
+      "adjustedUpperIncidence7Days": null
     },
     {
-      "cases7Days": 4437,
-      "incidence7Days": 5.34,
-      "date": "2021-11-19T00:00:00.000Z"
+      "cases7Days": 5221,
+      "incidence7Days": 6.28,
+      "date": "2022-02-25T00:00:00.000Z",
+      "fixedCases7Days": 5221,
+      "updatedCases7Days": 5221,
+      "adjustedLowerCases7Days": null,
+      "adjustedCases7Days": null,
+      "adjustedUpperCases7Days": null,
+      "fixedIncidence7Days": 6.28,
+      "updatedIncidence7Days": 6.28,
+      "adjustedLowerIncidence7Days": null,
+      "adjustedIncidence7Days": null,
+      "adjustedUpperIncidence7Days": null
     }
   ],
   "meta": {
     "source": "Robert Koch-Institut",
     "contact": "Marlon Lueckert (m.lueckert@me.com)",
     "info": "https://github.com/marlon360/rki-covid-api",
-    "lastUpdate": "2021-11-19T03:01:47.000Z",
-    "lastCheckedForUpdate": "2021-11-19T15:34:49.633Z"
+    "lastUpdate": "2022-02-25T04:05:31.000Z",
+    "lastCheckedForUpdate": "2022-02-25T06:41:49.840Z"
   }
 }
 ```

--- a/docs/endpoints/states.md
+++ b/docs/endpoints/states.md
@@ -182,6 +182,284 @@ Redirects to `/states/history/cases`
 
 ## `/states/history/hospitalization/:days`
 
+### Request
+
+`GET https://api.corona-zahlen.org/states/history/hospitalization/7`
+[Open](/states/history/hospitalization/7)
+
+**Parameters**
+
+| Parameter | Description                           |
+| --------- | ------------------------------------- |
+| :days     | Number of days in the past from today |
+
+### Response
+
+`cases7Days` updated number of hospitalization cases of the last 7 days.
+
+`incidence7Days` updated 7 day incidence of hospitalization.
+
+`date` publishing date of all values.
+
+Since 2021-03-09 the RKI is publisching adjusted (predicted) values for cases7Days and incidence7Days. If these values ​​are available, they are output below. These values are unavailable bevor 2021-03-09 and for the last 3 days.
+
+`fixedCases7Days` the number of 7 day cases witch is published at `date` first (fixed, that will never change!).
+
+`updatedCases7Days` the today updated number of 7 day cases and the same as `cases7Days`.
+
+`adjustedLowerCases7Days` the 95% lower limit adjusted (predicted) number of 7 day cases.
+
+`adjustedCases7Days` the adjusted (predicted) number of 7 day cases.
+
+`adjustedUpperCases7Days` the 95% upper limit adjusted (predicted) number of 7 day cases.
+
+`fixedIncidence7Days` the 7 day incidence witch is published at `date` first (fixed, that will never change!).
+
+`updatedIncidence7Days` the today updated 7 day incidence and the same as `incidence7Days`.
+
+`adjustedLowerIncidence7Days` the 95% lower limit adjusted (predicted) 7 day incidence.
+
+`adjustedIncidence7Days` the adjusted (predicted) 7 day incidence.
+
+`adjustedUpperIncidence7Days` the 95% upper limit adjusted (predicted) 7 day incidence.
+
+```json
+{
+  "data":{
+    "SH":{
+      "id":1,
+      "name":"Schleswig-Holstein",
+      "history":[
+        {
+          "cases7Days":229,
+          "incidence7Days":7.87,
+          "date":"2022-02-19T00:00:00.000Z",
+          "fixedCases7Days":176,
+          "updatedCases7Days":229,
+          "adjustedLowerCases7Days":277,
+          "adjustedCases7Days":283,
+          "adjustedUpperCases7Days":291,
+          "fixedIncidence7Days":6.05,
+          "updatedIncidence7Days":7.87,
+          "adjustedLowerIncidence7Days":9.53,
+          "adjustedIncidence7Days":9.74,
+          "adjustedUpperIncidence7Days":10.02
+        },
+        {
+          "cases7Days":232,
+          "incidence7Days":7.97,
+          "date":"2022-02-20T00:00:00.000Z",
+          "fixedCases7Days":181,
+          "updatedCases7Days":232,
+          "adjustedLowerCases7Days":283,
+          "adjustedCases7Days":289,
+          "adjustedUpperCases7Days":298,
+          "fixedIncidence7Days":6.22,
+          "updatedIncidence7Days":7.97,
+          "adjustedLowerIncidence7Days":9.74,
+          "adjustedIncidence7Days":9.96,
+          "adjustedUpperIncidence7Days":10.25
+        },
+        {
+          "cases7Days":234,
+          "incidence7Days":8.04,
+          "date":"2022-02-21T00:00:00.000Z",
+          "fixedCases7Days":181,
+          "updatedCases7Days":234,
+          "adjustedLowerCases7Days":287,
+          "adjustedCases7Days":294,
+          "adjustedUpperCases7Days":303,
+          "fixedIncidence7Days":6.22,
+          "updatedIncidence7Days":8.04,
+          "adjustedLowerIncidence7Days":9.87,
+          "adjustedIncidence7Days":10.1,
+          "adjustedUpperIncidence7Days":10.41
+        },
+        {
+          "cases7Days":224,
+          "incidence7Days":7.7,
+          "date":"2022-02-22T00:00:00.000Z",
+          "fixedCases7Days":176,
+          "updatedCases7Days":224,
+          "adjustedLowerCases7Days":285,
+          "adjustedCases7Days":292,
+          "adjustedUpperCases7Days":302,
+          "fixedIncidence7Days":6.05,
+          "updatedIncidence7Days":7.7,
+          "adjustedLowerIncidence7Days":9.8,
+          "adjustedIncidence7Days":10.04,
+          "adjustedUpperIncidence7Days":10.39
+        },
+        {
+          "cases7Days":209,
+          "incidence7Days":7.18,
+          "date":"2022-02-23T00:00:00.000Z",
+          "fixedCases7Days":169,
+          "updatedCases7Days":209,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":5.81,
+          "updatedIncidence7Days":7.18,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        },
+        {
+          "cases7Days":196,
+          "incidence7Days":6.73,
+          "date":"2022-02-24T00:00:00.000Z",
+          "fixedCases7Days":172,
+          "updatedCases7Days":196,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":5.91,
+          "updatedIncidence7Days":6.73,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        },
+        {
+          "cases7Days":187,
+          "incidence7Days":6.42,
+          "date":"2022-02-25T00:00:00.000Z",
+          "fixedCases7Days":187,
+          "updatedCases7Days":187,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":6.42,
+          "updatedIncidence7Days":6.42,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        }
+      ]
+    },
+    ...
+    "TH":{
+      "id":16,
+      "name":"Thüringen",
+      "history":[
+        {
+          "cases7Days":268,
+          "incidence7Days":12.64,
+          "date":"2022-02-19T00:00:00.000Z",
+          "fixedCases7Days":214,
+          "updatedCases7Days":268,
+          "adjustedLowerCases7Days":321,
+          "adjustedCases7Days":328,
+          "adjustedUpperCases7Days":334,
+          "fixedIncidence7Days":10.09,
+          "updatedIncidence7Days":12.64,
+          "adjustedLowerIncidence7Days":15.18,
+          "adjustedIncidence7Days":15.5,
+          "adjustedUpperIncidence7Days":15.8
+        },
+        {
+          "cases7Days":261,
+          "incidence7Days":12.31,
+          "date":"2022-02-20T00:00:00.000Z",
+          "fixedCases7Days":196,
+          "updatedCases7Days":261,
+          "adjustedLowerCases7Days":318,
+          "adjustedCases7Days":324,
+          "adjustedUpperCases7Days":332,
+          "fixedIncidence7Days":9.24,
+          "updatedIncidence7Days":12.31,
+          "adjustedLowerIncidence7Days":15.01,
+          "adjustedIncidence7Days":15.33,
+          "adjustedUpperIncidence7Days":15.68
+        },
+        {
+          "cases7Days":271,
+          "incidence7Days":12.78,
+          "date":"2022-02-21T00:00:00.000Z",
+          "fixedCases7Days":198,
+          "updatedCases7Days":271,
+          "adjustedLowerCases7Days":334,
+          "adjustedCases7Days":342,
+          "adjustedUpperCases7Days":350,
+          "fixedIncidence7Days":9.34,
+          "updatedIncidence7Days":12.78,
+          "adjustedLowerIncidence7Days":15.8,
+          "adjustedIncidence7Days":16.13,
+          "adjustedUpperIncidence7Days":16.52
+        },
+        {
+          "cases7Days":288,
+          "incidence7Days":13.58,
+          "date":"2022-02-22T00:00:00.000Z",
+          "fixedCases7Days":212,
+          "updatedCases7Days":288,
+          "adjustedLowerCases7Days":364,
+          "adjustedCases7Days":372,
+          "adjustedUpperCases7Days":382,
+          "fixedIncidence7Days":10,
+          "updatedIncidence7Days":13.58,
+          "adjustedLowerIncidence7Days":17.21,
+          "adjustedIncidence7Days":17.58,
+          "adjustedUpperIncidence7Days":18.03
+        },
+        {
+          "cases7Days":275,
+          "incidence7Days":12.97,
+          "date":"2022-02-23T00:00:00.000Z",
+          "fixedCases7Days":221,
+          "updatedCases7Days":275,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":10.42,
+          "updatedIncidence7Days":12.97,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        },
+        {
+          "cases7Days":249,
+          "incidence7Days":11.74,
+          "date":"2022-02-24T00:00:00.000Z",
+          "fixedCases7Days":203,
+          "updatedCases7Days":249,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":9.57,
+          "updatedIncidence7Days":11.74,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        },
+        {
+          "cases7Days":225,
+          "incidence7Days":10.61,
+          "date":"2022-02-25T00:00:00.000Z",
+          "fixedCases7Days":225,
+          "updatedCases7Days":225,
+          "adjustedLowerCases7Days":null,
+          "adjustedCases7Days":null,
+          "adjustedUpperCases7Days":null,
+          "fixedIncidence7Days":10.61,
+          "updatedIncidence7Days":10.61,
+          "adjustedLowerIncidence7Days":null,
+          "adjustedIncidence7Days":null,
+          "adjustedUpperIncidence7Days":null
+        }
+      ]
+    }
+  },
+  "meta":{
+    "source":"Robert Koch-Institut",
+    "contact":"Marlon Lueckert (m.lueckert@me.com)",
+    "info":"https://github.com/marlon360/rki-covid-api",
+    "lastUpdate":"2022-02-25T04:05:31.000Z",
+    "lastCheckedForUpdate":"2022-02-25T07:24:43.163Z"
+  }
+}
+```
+
 ## `/states/age-groups`
 
 ### Request

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -197,7 +197,21 @@ export async function GermanyRecoveredHistoryResponse(
 export async function GermanyHospitalizationHistoryResponse(
   days?: number
 ): Promise<
-  GermanyHistoryData<{ cases7Days: number; incidence7Days: number; date: Date }>
+  GermanyHistoryData<{
+    cases7Days: number; //legacy
+    incidence7Days: number; //legacy
+    date: Date;
+    fixedCases7Days: number;
+    updatedCases7Days: number;
+    adjustedLowerCases7Days: number;
+    adjustedCases7Days: number;
+    adjustedUpperCases7Days: number;
+    fixedIncidence7Days: number;
+    updatedIncidence7Days: number;
+    adjustedLowerIncidence7Days: number;
+    adjustedIncidence7Days: number;
+    adjustedUpperIncidence7Days: number;
+  }>
 > {
   if (days != null && isNaN(days)) {
     throw new TypeError(
@@ -218,9 +232,26 @@ export async function GermanyHospitalizationHistoryResponse(
   });
   dateKeys.forEach((dateKey) => {
     history.push({
-      cases7Days: hospitalizationData.data[dateKey].cases7Days,
-      incidence7Days: hospitalizationData.data[dateKey].incidence7Days,
+      cases7Days: hospitalizationData.data[dateKey].cases7Days, //legacy
+      incidence7Days: hospitalizationData.data[dateKey].incidence7Days, //legacy
       date: new Date(dateKey),
+      fixedCases7Days: hospitalizationData.data[dateKey].fixedCases7Days,
+      updatedCases7Days: hospitalizationData.data[dateKey].updatedCases7Days,
+      adjustedLowerCases7Days:
+        hospitalizationData.data[dateKey].adjustedLowerCases7Days,
+      adjustedCases7Days: hospitalizationData.data[dateKey].adjustedCases7Days,
+      adjustedUpperCases7Days:
+        hospitalizationData.data[dateKey].adjustedUpperCases7Days,
+      fixedIncidence7Days:
+        hospitalizationData.data[dateKey].fixedIncidence7Days,
+      updatedIncidence7Days:
+        hospitalizationData.data[dateKey].updatedIncidence7Days,
+      adjustedLowerIncidence7Days:
+        hospitalizationData.data[dateKey].adjustedLowerIncidence7Days,
+      adjustedIncidence7Days:
+        hospitalizationData.data[dateKey].adjustedIncidence7Days,
+      adjustedUpperIncidence7Days:
+        hospitalizationData.data[dateKey].adjustedUpperIncidence7Days,
     });
   });
 

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -430,9 +430,19 @@ interface StatesHospitalizationHistory {
       name: string;
       history: [
         {
-          cases7Days: number;
-          incidence7Days: number;
+          cases7Days: number; //legacy
+          incidence7Days: number; //legacy
           date: Date;
+          fixedCases7Days: number;
+          updatedCases7Days: number;
+          adjustedLowerCases7Days: number;
+          adjustedCases7Days: number;
+          adjustedUpperCases7Days: number;
+          fixedIncidence7Days: number;
+          updatedIncidence7Days: number;
+          adjustedLowerIncidence7Days: number;
+          adjustedIncidence7Days: number;
+          adjustedUpperIncidence7days: number;
         }
       ];
     };
@@ -480,10 +490,39 @@ export async function StatesHospitalizationHistoryResponse(
         }
         historyData[abbreviation].history.push({
           cases7Days:
-            hospitalizationData.data[dateKey].states[stateName].cases7Days,
+            hospitalizationData.data[dateKey].states[stateName].cases7Days, //legacy
           incidence7Days:
-            hospitalizationData.data[dateKey].states[stateName].incidence7Days,
+            hospitalizationData.data[dateKey].states[stateName].incidence7Days, //legacy
           date: new Date(dateKey),
+          fixedCases7Days:
+            hospitalizationData.data[dateKey].states[stateName].fixedCases7Days,
+          updatedCases7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .updatedCases7Days,
+          adjustedLowerCases7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedLowerCases7Days,
+          adjustedCases7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedCases7Days,
+          adjustedUpperCases7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedUpperCases7Days,
+          fixedIncidence7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .fixedIncidence7Days,
+          updatedIncidence7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .updatedIncidence7Days,
+          adjustedLowerIncidence7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedLowerIncidence7Days,
+          adjustedIncidence7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedIncidence7Days,
+          adjustedUpperIncidence7Days:
+            hospitalizationData.data[dateKey].states[stateName]
+              .adjustedUpperIncidence7Days,
         });
       });
     } else if (abbreviationList.includes(p_abbreviation)) {
@@ -498,10 +537,38 @@ export async function StatesHospitalizationHistoryResponse(
       }
       historyData[p_abbreviation].history.push({
         cases7Days:
-          hospitalizationData.data[dateKey].states[stateName].cases7Days,
+          hospitalizationData.data[dateKey].states[stateName].cases7Days, //legacy
         incidence7Days:
-          hospitalizationData.data[dateKey].states[stateName].incidence7Days,
+          hospitalizationData.data[dateKey].states[stateName].incidence7Days, //legacy
         date: new Date(dateKey),
+        fixedCases7Days:
+          hospitalizationData.data[dateKey].states[stateName].fixedCases7Days,
+        updatedCases7Days:
+          hospitalizationData.data[dateKey].states[stateName].updatedCases7Days,
+        adjustedLowerCases7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedLowerCases7Days,
+        adjustedCases7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedCases7Days,
+        adjustedUpperCases7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedUpperCases7Days,
+        fixedIncidence7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .fixedIncidence7Days,
+        updatedIncidence7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .updatedIncidence7Days,
+        adjustedLowerIncidence7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedLowerIncidence7Days,
+        adjustedIncidence7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedIncidence7Days,
+        adjustedUpperIncidence7Days:
+          hospitalizationData.data[dateKey].states[stateName]
+            .adjustedUpperIncidence7Days,
       });
     } else {
       throw new Error(


### PR DESCRIPTION
add adjusted (predicted) values to hospitalisation history including the 95% prediction intervals..

Explanation of the adjusted 7-day hospitalization incidence.
The reported hospitalization incidence is supplemented with an estimate of the expected number of delayed hospitalizations reported. The adjustment should allow a better classification of the current trend in the number of hospitalized and the 7-day hospitalization incidence.

Erläuterung zur adjustierten 7-Tage-Hospitalisierungsinzidenz.
Die berichtete Hospitalisierungsinzidenz wird um eine Schätzung der zu erwartenden Anzahl an verzögert berichteten Hospitalisierungen erweitert. Die Adjustierung soll eine bessere Einordnung des aktuellen Trends der Anzahl Hospitalisierter und der 7-Tage-Hospitalisierungsinzidenz erlauben. 