### PR TITLE
single states data source as backup

### DIFF
--- a/src/data-requests/districts.ts
+++ b/src/data-requests/districts.ts
@@ -66,7 +66,10 @@ export async function getDistrictsRecoveredData(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -95,7 +98,10 @@ export async function getNewDistrictCases(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -124,7 +130,10 @@ export async function getNewDistrictDeaths(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -156,7 +165,10 @@ export async function getNewDistrictRecovered(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -209,7 +221,10 @@ export async function getLastDistrictCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);
@@ -276,7 +291,10 @@ export async function getLastDistrictDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);
@@ -343,7 +361,10 @@ export async function getLastDistrictRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);

--- a/src/data-requests/districts.ts
+++ b/src/data-requests/districts.ts
@@ -66,7 +66,7 @@ export async function getDistrictsRecoveredData(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -95,7 +95,7 @@ export async function getNewDistrictCases(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -124,7 +124,7 @@ export async function getNewDistrictDeaths(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -156,7 +156,7 @@ export async function getNewDistrictRecovered(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const districts = data.features.map((feature) => {
@@ -209,7 +209,7 @@ export async function getLastDistrictCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);
@@ -276,7 +276,7 @@ export async function getLastDistrictDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);
@@ -343,7 +343,7 @@ export async function getLastDistrictRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a ags is given get only the data from the specific states table
     if (ags) {
       const blId = ags.padStart(2, "0").substring(0, 2);

--- a/src/data-requests/districts.ts
+++ b/src/data-requests/districts.ts
@@ -180,7 +180,7 @@ export async function getLastDistrictCasesHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = ags ? ags.padStart(2, "0").substring(0, 2) : null;
+    const blId = ags ? ags.padStart(5, "0").substring(0, 2) : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }
@@ -236,7 +236,7 @@ export async function getLastDistrictDeathsHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = ags ? ags.padStart(2, "0").substring(0, 2) : null;
+    const blId = ags ? ags.padStart(5, "0").substring(0, 2) : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }
@@ -292,7 +292,7 @@ export async function getLastDistrictRecoveredHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = ags ? ags.padStart(2, "0").substring(0, 2) : null;
+    const blId = ags ? ags.padStart(5, "0").substring(0, 2) : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }

--- a/src/data-requests/germany.ts
+++ b/src/data-requests/germany.ts
@@ -1,38 +1,77 @@
 import axios from "axios";
 import { ResponseData } from "./response-data";
-import { getDateBefore, RKIError } from "../utils";
+import {
+  getDateBefore,
+  RKIError,
+  parseDate,
+  getDataAlternateSource,
+} from "../utils";
 
 export async function getCases(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let cases = 0;
+    for (const feature of dataTemp.features) {
+      cases += feature.attributes.cases;
+    }
+    data.features[0].attributes.cases = cases;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.cases,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewCases(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let cases = 0;
+    for (const feature of dataTemp.features) {
+      cases += feature.attributes.cases;
+    }
+    data.features[0].attributes.cases = cases;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.cases,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getLastCasesHistory(
   days?: number
-): Promise<{ cases: number; date: Date }[]> {
+): Promise<{ history: { cases: number; date: Date }[]; lastUpdate: Date }> {
   const whereParams = ["NeuerFall IN(1,0)"];
   if (days != null) {
     const dateString = getDateBefore(days);
@@ -40,24 +79,55 @@ export async function getLastCasesHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
-  const data = response.data;
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
-  return data.features.map((feature) => {
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    // dataTemp must be aggregated and summed
+    data.features = [];
+    dataTemp.features.reduce(function (res, feature) {
+      if (!res[feature.attributes.date]) {
+        res[feature.attributes.date] = {
+          attributes: {
+            date: feature.attributes.date,
+            cases: 0,
+            Datenstand: feature.attributes.Datenstand,
+          },
+        };
+        data.features.push(res[feature.attributes.date]);
+      }
+      res[feature.attributes.date].attributes.cases += feature.attributes.cases;
+      return res;
+    }, {});
+  }
+  const history = data.features.map((feature) => {
     return {
       cases: feature.attributes.cases,
       date: new Date(feature.attributes.date),
     };
   });
+  return {
+    history: history,
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
+  };
 }
 
 export async function getLastDeathsHistory(
   days?: number
-): Promise<{ deaths: number; date: Date }[]> {
+): Promise<{ history: { deaths: number; date: Date }[]; lastUpdate: Date }> {
   const whereParams = ["NeuerTodesfall IN(1,0,-9)"];
   if (days != null) {
     const dateString = getDateBefore(days);
@@ -65,24 +135,56 @@ export async function getLastDeathsHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
-  return data.features.map((feature) => {
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    // dataTemp must be aggregated and summed
+    data.features = [];
+    dataTemp.features.reduce(function (res, feature) {
+      if (!res[feature.attributes.date]) {
+        res[feature.attributes.date] = {
+          attributes: {
+            date: feature.attributes.date,
+            deaths: 0,
+            Datenstand: feature.attributes.Datenstand,
+          },
+        };
+        data.features.push(res[feature.attributes.date]);
+      }
+      res[feature.attributes.date].attributes.deaths +=
+        feature.attributes.deaths;
+      return res;
+    }, {});
+  }
+  const history = data.features.map((feature) => {
     return {
       deaths: feature.attributes.deaths,
       date: new Date(feature.attributes.date),
     };
   });
+  return {
+    history: history,
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
+  };
 }
 
 export async function getLastRecoveredHistory(
   days?: number
-): Promise<{ recovered: number; date: Date }[]> {
+): Promise<{ history: { recovered: number; date: Date }[]; lastUddate: Date }> {
   const whereParams = ["NeuGenesen IN(1,0,-9)"];
   if (days != null) {
     const dateString = getDateBefore(days);
@@ -90,74 +192,174 @@ export async function getLastRecoveredHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=MeldeDatum&groupByFieldsForStatistics=MeldeDatum,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
-  return data.features.map((feature) => {
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    // dataTemp must be aggregated and summed
+    data.features = [];
+    dataTemp.features.reduce(function (res, feature) {
+      if (!res[feature.attributes.date]) {
+        res[feature.attributes.date] = {
+          attributes: {
+            date: feature.attributes.date,
+            recovered: 0,
+            Datenstand: feature.attributes.Datenstand,
+          },
+        };
+        data.features.push(res[feature.attributes.date]);
+      }
+      res[feature.attributes.date].attributes.recovered +=
+        feature.attributes.recovered;
+      return res;
+    }, {});
+  }
+  const history = data.features.map((feature) => {
     return {
       recovered: feature.attributes.recovered,
       date: new Date(feature.attributes.date),
     };
   });
+  return {
+    history: history,
+    lastUddate: parseDate(data.features[0].attributes.Datenstand),
+  };
 }
 
 export async function getDeaths(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let deaths = 0;
+    for (const feature of dataTemp.features) {
+      deaths += feature.attributes.deaths;
+    }
+    data.features[0].attributes.deaths = deaths;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.deaths,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewDeaths(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let deaths = 0;
+    for (const feature of dataTemp.features) {
+      deaths += feature.attributes.deaths;
+    }
+    data.features[0].attributes.deaths = deaths;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.deaths,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getRecovered(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let recovered = 0;
+    for (const feature of dataTemp.features) {
+      recovered += feature.attributes.recovered;
+    }
+    data.features[0].attributes.recovered = recovered;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.recovered,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewRecovered(): Promise<ResponseData<number>> {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatumDatenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
   const data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
   }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    const dataTemp = await getDataAlternateSource(url);
+    let recovered = 0;
+    for (const feature of dataTemp.features) {
+      recovered += feature.attributes.recovered;
+    }
+    data.features[0].attributes.recovered = recovered;
+    data.features[0].attributes.Datenstand =
+      dataTemp.features[0].attributes.Datenstand;
+  }
   return {
     data: data.features[0].attributes.recovered,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 

--- a/src/data-requests/germany.ts
+++ b/src/data-requests/germany.ts
@@ -22,7 +22,7 @@ export async function getCases(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( Datenstand - actualDate ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let cases = 0;
     for (const feature of dataTemp.features) {
@@ -53,7 +53,7 @@ export async function getNewCases(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let cases = 0;
     for (const feature of dataTemp.features) {
@@ -94,7 +94,7 @@ export async function getLastCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -118,6 +118,10 @@ export async function getLastCasesHistory(
       cases: feature.attributes.cases,
       date: new Date(feature.attributes.date),
     };
+  }).sort((a, b) => {
+    const dateA = a.date;
+    const dateB = b.date;
+    return dateA.getTime() - dateB.getTime();
   });
   return {
     history: history,
@@ -150,7 +154,7 @@ export async function getLastDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -175,6 +179,10 @@ export async function getLastDeathsHistory(
       deaths: feature.attributes.deaths,
       date: new Date(feature.attributes.date),
     };
+  }).sort((a, b) => {
+    const dateA = a.date;
+    const dateB = b.date;
+    return dateA.getTime() - dateB.getTime();
   });
   return {
     history: history,
@@ -207,7 +215,7 @@ export async function getLastRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -232,6 +240,10 @@ export async function getLastRecoveredHistory(
       recovered: feature.attributes.recovered,
       date: new Date(feature.attributes.date),
     };
+  }).sort((a, b) => {
+    const dateA = a.date;
+    const dateB = b.date;
+    return dateA.getTime() - dateB.getTime();
   });
   return {
     history: history,
@@ -254,7 +266,7 @@ export async function getDeaths(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let deaths = 0;
     for (const feature of dataTemp.features) {
@@ -285,7 +297,7 @@ export async function getNewDeaths(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let deaths = 0;
     for (const feature of dataTemp.features) {
@@ -316,7 +328,7 @@ export async function getRecovered(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let recovered = 0;
     for (const feature of dataTemp.features) {
@@ -347,7 +359,7 @@ export async function getNewRecovered(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     const dataTemp = await getDataAlternateSource(url);
     let recovered = 0;
     for (const feature of dataTemp.features) {

--- a/src/data-requests/germany.ts
+++ b/src/data-requests/germany.ts
@@ -22,7 +22,10 @@ export async function getCases(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( Datenstand - actualDate ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    Datenstand - actualDate > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let cases = 0;
     for (const feature of dataTemp.features) {
@@ -53,7 +56,10 @@ export async function getNewCases(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let cases = 0;
     for (const feature of dataTemp.features) {
@@ -94,7 +100,10 @@ export async function getLastCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -113,16 +122,18 @@ export async function getLastCasesHistory(
       return res;
     }, {});
   }
-  const history = data.features.map((feature) => {
-    return {
-      cases: feature.attributes.cases,
-      date: new Date(feature.attributes.date),
-    };
-  }).sort((a, b) => {
-    const dateA = a.date;
-    const dateB = b.date;
-    return dateA.getTime() - dateB.getTime();
-  });
+  const history = data.features
+    .map((feature) => {
+      return {
+        cases: feature.attributes.cases,
+        date: new Date(feature.attributes.date),
+      };
+    })
+    .sort((a, b) => {
+      const dateA = a.date;
+      const dateB = b.date;
+      return dateA.getTime() - dateB.getTime();
+    });
   return {
     history: history,
     lastUpdate: parseDate(data.features[0].attributes.Datenstand),
@@ -154,7 +165,10 @@ export async function getLastDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -174,16 +188,18 @@ export async function getLastDeathsHistory(
       return res;
     }, {});
   }
-  const history = data.features.map((feature) => {
-    return {
-      deaths: feature.attributes.deaths,
-      date: new Date(feature.attributes.date),
-    };
-  }).sort((a, b) => {
-    const dateA = a.date;
-    const dateB = b.date;
-    return dateA.getTime() - dateB.getTime();
-  });
+  const history = data.features
+    .map((feature) => {
+      return {
+        deaths: feature.attributes.deaths,
+        date: new Date(feature.attributes.date),
+      };
+    })
+    .sort((a, b) => {
+      const dateA = a.date;
+      const dateB = b.date;
+      return dateA.getTime() - dateB.getTime();
+    });
   return {
     history: history,
     lastUpdate: parseDate(data.features[0].attributes.Datenstand),
@@ -215,7 +231,10 @@ export async function getLastRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     // dataTemp must be aggregated and summed
     data.features = [];
@@ -235,16 +254,18 @@ export async function getLastRecoveredHistory(
       return res;
     }, {});
   }
-  const history = data.features.map((feature) => {
-    return {
-      recovered: feature.attributes.recovered,
-      date: new Date(feature.attributes.date),
-    };
-  }).sort((a, b) => {
-    const dateA = a.date;
-    const dateB = b.date;
-    return dateA.getTime() - dateB.getTime();
-  });
+  const history = data.features
+    .map((feature) => {
+      return {
+        recovered: feature.attributes.recovered,
+        date: new Date(feature.attributes.date),
+      };
+    })
+    .sort((a, b) => {
+      const dateA = a.date;
+      const dateB = b.date;
+      return dateA.getTime() - dateB.getTime();
+    });
   return {
     history: history,
     lastUddate: parseDate(data.features[0].attributes.Datenstand),
@@ -266,7 +287,10 @@ export async function getDeaths(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let deaths = 0;
     for (const feature of dataTemp.features) {
@@ -297,7 +321,10 @@ export async function getNewDeaths(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let deaths = 0;
     for (const feature of dataTemp.features) {
@@ -328,7 +355,10 @@ export async function getRecovered(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let recovered = 0;
     for (const feature of dataTemp.features) {
@@ -359,7 +389,10 @@ export async function getNewRecovered(): Promise<ResponseData<number>> {
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     const dataTemp = await getDataAlternateSource(url);
     let recovered = 0;
     for (const feature of dataTemp.features) {

--- a/src/data-requests/states.ts
+++ b/src/data-requests/states.ts
@@ -176,7 +176,7 @@ export async function getLastStateCasesHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = id ? id.toString().padStart(2, "0").substring(0, 2) : null;
+    const blId = id ? id.toString().padStart(2, "0") : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }
@@ -225,7 +225,7 @@ export async function getLastStateDeathsHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = id ? id.toString().padStart(2, "0").substring(0, 2) : null;
+    const blId = id ? id.toString().padStart(2, "0") : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }
@@ -274,7 +274,7 @@ export async function getLastStateRecoveredHistory(
   }
   let datenstand = parseDate(data.features[0].attributes.Datenstand);
   if (shouldUseAlternateDataSource(datenstand)) {
-    const blId = id ? id.toString().padStart(2, "0").substring(0, 2) : null;
+    const blId = id ? id.toString().padStart(2, "0") : null;
     data = await getAlternateDataSource(url, blId);
     datenstand = parseDate(data.features[0].attributes.Datenstand);
   }

--- a/src/data-requests/states.ts
+++ b/src/data-requests/states.ts
@@ -63,7 +63,7 @@ export async function getStatesRecoveredData(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -95,7 +95,7 @@ export async function getNewStateRecovered(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -127,7 +127,7 @@ export async function getNewStateCases(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -159,7 +159,7 @@ export async function getNewStateDeaths(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -205,7 +205,7 @@ export async function getLastStateCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);
@@ -265,7 +265,7 @@ export async function getLastStateDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);
@@ -325,7 +325,7 @@ export async function getLastStateRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (Datenstand != actualDate && nowTime > threeOclock) {
+  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);

--- a/src/data-requests/states.ts
+++ b/src/data-requests/states.ts
@@ -1,5 +1,11 @@
 import axios from "axios";
-import { getDateBefore, getStateAbbreviationById, RKIError } from "../utils";
+import {
+  getDateBefore,
+  getStateAbbreviationById,
+  RKIError,
+  getDataAlternateSource,
+  parseDate,
+} from "../utils";
 import { ResponseData } from "./response-data";
 
 export interface IStateData {
@@ -43,12 +49,22 @@ export async function getStatesData(): Promise<ResponseData<IStateData[]>> {
 export async function getStatesRecoveredData(): Promise<
   ResponseData<{ id: number; recovered: number }[]>
 > {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,IdBundeland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
-  const data = response.data;
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,0)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,IdBundeland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
     return {
@@ -58,19 +74,29 @@ export async function getStatesRecoveredData(): Promise<
   });
   return {
     data: states,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewStateRecovered(): Promise<
   ResponseData<{ id: number; recovered: number }[]>
 > {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,IdBundeland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
-  const data = response.data;
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuGenesen IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,IdBundeland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
     return {
@@ -80,19 +106,29 @@ export async function getNewStateRecovered(): Promise<
   });
   return {
     data: states,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewStateCases(): Promise<
   ResponseData<{ id: number; cases: number }[]>
 > {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,IdBundeland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
-  const data = response.data;
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerFall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,IdBundeland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
     return {
@@ -102,19 +138,29 @@ export async function getNewStateCases(): Promise<
   });
   return {
     data: states,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
 export async function getNewStateDeaths(): Promise<
   ResponseData<{ id: number; deaths: number }[]>
 > {
-  const response = await axios.get(
-    `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,IdBundeland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`
-  );
-  const data = response.data;
+  const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=NeuerTodesfall IN(1,-1)&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,IdBundeland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland&groupByFieldsForStatistics=IdBundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"},{"statisticType":"max","onStatisticField":"MeldeDatum","outStatisticFieldName":"date"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  const response = await axios.get(url);
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime();
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
     return {
@@ -124,7 +170,7 @@ export async function getNewStateDeaths(): Promise<
   });
   return {
     data: states,
-    lastUpdate: new Date(data.features[0].attributes.date),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
@@ -144,12 +190,29 @@ export async function getLastStateCasesHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,Bundesland,IdBundesland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlFall,MeldeDatum,Bundesland,IdBundesland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlFall","outStatisticFieldName":"cases"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
-  const data = response.data;
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime(); //now im milliseconds
+  const actualDate = now.setHours(0, 0, 0, 0); // date 0:00 GMT
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime(); // Datenstand im milliseconds
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    // if a state id is given get only the data from the specific states table
+    if (id) {
+      const blId = id.toString().padStart(2, "0").substring(0, 2);
+      data = await getDataAlternateSource(url, blId);
+    } else {
+      data = await getDataAlternateSource(url);
+    }
   }
   const history: {
     id: number;
@@ -167,9 +230,7 @@ export async function getLastStateCasesHistory(
 
   return {
     data: history,
-    lastUpdate: history[history.length - 1]
-      ? history[history.length - 1].date
-      : new Date(),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
@@ -189,12 +250,29 @@ export async function getLastStateDeathsHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,Bundesland,IdBundesland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlTodesfall,MeldeDatum,Bundesland,IdBundesland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlTodesfall","outStatisticFieldName":"deaths"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
-  const data = response.data;
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime(); //now im milliseconds
+  const actualDate = now.setHours(0, 0, 0, 0); // date 0:00 GMT
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime(); // Datenstand im milliseconds
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    // if a state id is given get only the data from the specific states table
+    if (id) {
+      const blId = id.toString().padStart(2, "0").substring(0, 2);
+      data = await getDataAlternateSource(url, blId);
+    } else {
+      data = await getDataAlternateSource(url);
+    }
   }
   const history: {
     id: number;
@@ -212,9 +290,7 @@ export async function getLastStateDeathsHistory(
 
   return {
     data: history,
-    lastUpdate: history[history.length - 1]
-      ? history[history.length - 1].date
-      : new Date(),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 
@@ -234,12 +310,29 @@ export async function getLastStateRecoveredHistory(
   }
   const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Covid19_hubv/FeatureServer/0/query?where=${whereParams.join(
     " AND "
-  )}&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,Bundesland,IdBundesland&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
+  )}&objectIds=&time=&resultType=standard&outFields=AnzahlGenesen,MeldeDatum,Bundesland,IdBundesland,Datenstand&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=false&cacheHint=false&orderByFields=IdBundesland,MeldeDatum&groupByFieldsForStatistics=IdBundesland,MeldeDatum,Bundesland,Datenstand&outStatistics=[{"statisticType":"sum","onStatisticField":"AnzahlGenesen","outStatisticFieldName":"recovered"}]&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=json&token=`;
 
   const response = await axios.get(url);
-  const data = response.data;
+  let data = response.data;
   if (data.error) {
     throw new RKIError(data.error, response.config.url);
+  }
+  // check if data is updated, if not try alternate download from separately state tables
+  const now = new Date();
+  const nowTime = now.getTime(); //now im milliseconds
+  const actualDate = now.setHours(0, 0, 0, 0); // date 0:00 GMT
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const Datenstand = parseDate(
+    data.features[0].attributes.Datenstand
+  ).getTime(); // Datenstand im milliseconds
+  if (Datenstand != actualDate && nowTime > threeOclock) {
+    // if a state id is given get only the data from the specific states table
+    if (id) {
+      const blId = id.toString().padStart(2, "0").substring(0, 2);
+      data = await getDataAlternateSource(url, blId);
+    } else {
+      data = await getDataAlternateSource(url);
+    }
   }
   const history: {
     id: number;
@@ -257,9 +350,7 @@ export async function getLastStateRecoveredHistory(
 
   return {
     data: history,
-    lastUpdate: history[history.length - 1]
-      ? history[history.length - 1].date
-      : new Date(),
+    lastUpdate: parseDate(data.features[0].attributes.Datenstand),
   };
 }
 

--- a/src/data-requests/states.ts
+++ b/src/data-requests/states.ts
@@ -63,7 +63,10 @@ export async function getStatesRecoveredData(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -95,7 +98,10 @@ export async function getNewStateRecovered(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -127,7 +133,10 @@ export async function getNewStateCases(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -159,7 +168,10 @@ export async function getNewStateDeaths(): Promise<
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime();
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     data = await getDataAlternateSource(url);
   }
   const states = data.features.map((feature) => {
@@ -205,7 +217,10 @@ export async function getLastStateCasesHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);
@@ -265,7 +280,10 @@ export async function getLastStateDeathsHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);
@@ -325,7 +343,10 @@ export async function getLastStateRecoveredHistory(
   const Datenstand = parseDate(
     data.features[0].attributes.Datenstand
   ).getTime(); // Datenstand im milliseconds
-  if (( actualDate - Datenstand ) > 24 * 60 * 60000 || ( Datenstand != actualDate && nowTime > threeOclock )) {
+  if (
+    actualDate - Datenstand > 24 * 60 * 60000 ||
+    (Datenstand != actualDate && nowTime > threeOclock)
+  ) {
     // if a state id is given get only the data from the specific states table
     if (id) {
       const blId = id.toString().padStart(2, "0").substring(0, 2);

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -135,8 +135,8 @@ export async function GermanyCasesHistoryResponse(
 ): Promise<GermanyHistoryData<{ cases: number; date: Date }>> {
   const history = await getLastCasesHistory(days);
   return {
-    data: history,
-    meta: new ResponseMeta(new Date(history[history.length - 1].date)),
+    data: history.history,
+    meta: new ResponseMeta(history.lastUpdate),
   };
 }
 
@@ -156,7 +156,7 @@ export async function GermanyWeekIncidenceHistoryResponse(
 
   const weekIncidenceHistory: { weekIncidence: number; date: Date }[] = [];
 
-  for (let i = 6; i < history.length; i++) {
+  for (let i = 6; i < history.history.length; i++) {
     const date = history[i].date;
     let sum = 0;
     for (let dayOffset = i; dayOffset > i - 7; dayOffset--) {
@@ -170,7 +170,7 @@ export async function GermanyWeekIncidenceHistoryResponse(
 
   return {
     data: weekIncidenceHistory,
-    meta: new ResponseMeta(new Date(history[history.length - 1].date)),
+    meta: new ResponseMeta(history.lastUpdate),
   };
 }
 
@@ -179,8 +179,8 @@ export async function GermanyDeathsHistoryResponse(
 ): Promise<GermanyHistoryData<{ deaths: number; date: Date }>> {
   const history = await getLastDeathsHistory(days);
   return {
-    data: history,
-    meta: new ResponseMeta(new Date(history[history.length - 1].date)),
+    data: history.history,
+    meta: new ResponseMeta(history.lastUpdate),
   };
 }
 
@@ -189,8 +189,8 @@ export async function GermanyRecoveredHistoryResponse(
 ): Promise<GermanyHistoryData<{ recovered: number; date: Date }>> {
   const history = await getLastRecoveredHistory(days);
   return {
-    data: history,
-    meta: new ResponseMeta(new Date(history[history.length - 1].date)),
+    data: history.history,
+    meta: new ResponseMeta(history.lastUddate),
   };
 }
 

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -190,7 +190,7 @@ export async function GermanyRecoveredHistoryResponse(
   const history = await getLastRecoveredHistory(days);
   return {
     data: history.history,
-    meta: new ResponseMeta(history.lastUddate),
+    meta: new ResponseMeta(history.lastUpdate),
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -263,53 +263,16 @@ export async function getAlternateDataSource(url: string, blId?: string) {
   }
   // else download all 16 state data
   else {
-    const blPromise = [];
-    const blData = [];
+    const blPromises = [];
     // build Promises
     for (let i = 0; i <= 15; i++) {
-      blPromise[i] = new Promise(async (resolve) => {
-        const id = (i + 1).toString().padStart(2, "0");
-        const blUrl = url.replace("Covid19_hubv", `Covid19_${id}_hubv`);
-        axios.get(blUrl).then((response) => {
-          resolve(response.data);
-        });
+      const id = (i + 1).toString().padStart(2, "0");
+      const blUrl = url.replace("Covid19_hubv", `Covid19_${id}_hubv`);
+      blPromises[i] = axios.get(blUrl).then((response) => {
+        return response.data;
       });
     }
-    [
-      blData[0],
-      blData[1],
-      blData[2],
-      blData[3],
-      blData[4],
-      blData[5],
-      blData[6],
-      blData[7],
-      blData[8],
-      blData[9],
-      blData[10],
-      blData[11],
-      blData[12],
-      blData[13],
-      blData[14],
-      blData[15],
-    ] = await Promise.all([
-      blPromise[0],
-      blPromise[1],
-      blPromise[2],
-      blPromise[3],
-      blPromise[4],
-      blPromise[5],
-      blPromise[6],
-      blPromise[7],
-      blPromise[8],
-      blPromise[9],
-      blPromise[10],
-      blPromise[11],
-      blPromise[12],
-      blPromise[13],
-      blPromise[14],
-      blPromise[15],
-    ]);
+    const blData = await Promise.all(blPromises);
     var data = blData[0];
     for (let i = 1; i <= 15; i++) {
       // append the data

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,7 +262,7 @@ export async function getAlternateDataSource(url: string, blId?: string) {
   }
   // else download all 16 state data
   else {
-    const blData = []; 
+    const blData = [];
     [
       blData[1],
       blData[2],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosPromise, AxiosResponse } from "axios";
 
 export function getStateAbbreviationById(id: number): string | null {
   switch (id) {
@@ -249,31 +249,141 @@ export function parseDate(dateString: string): Date {
   );
 }
 
-export async function getDataAlternateSource(url: string, blId?: string) {
+export async function getAlternateDataSource(url: string, blId?: string) {
   // If a specific table is given download this state data only
   let stateIdList = [];
   for (let id = 1; id <= 16; id++) {
     stateIdList[id - 1] = id.toString().padStart(2, "0");
   }
   if (blId && stateIdList.includes(blId)) {
-    const urlOne = url.replace("Covid19_hubv", `Covid19_${blId}_hubv`);
-    const response = await axios.get(urlOne);
+    url = url.replace("Covid19_hubv", `Covid19_${blId}_hubv`);
+    const response = await axios.get(url);
     var data = response.data;
   }
   // else download all 16 state data
   else {
-    const urlOne = url.replace("Covid19_hubv", "Covid19_01_hubv");
-    let response = await axios.get(urlOne);
-    var data = response.data;
-    for (let i = 2; i <= 16; i++) {
-      const id = i.toString().padStart(2, "0");
-      const urlX = url.replace("Covid19_hubv", `Covid19_${id}_hubv`);
-      response = await axios.get(urlX);
-      // append the data
-      for (const feature of response.data.features) {
-        data.features.push(feature);
+    const blData = []; 
+    [
+      blData[1],
+      blData[2],
+      blData[3],
+      blData[4],
+      blData[5],
+      blData[6],
+      blData[7],
+      blData[8],
+      blData[9],
+      blData[10],
+      blData[11],
+      blData[12],
+      blData[13],
+      blData[14],
+      blData[15],
+      blData[16],
+    ] = await Promise.all([
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_01_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_02_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_03_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_04_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_05_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_06_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_07_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_08_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_09_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_10_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_11_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_12_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_13_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_14_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_15_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+      axios
+        .get(url.replace("Covid19_hubv", `Covid19_16_hubv`))
+        .then((response) => {
+          return response.data;
+        }),
+    ]);
+    for (let i = 1; i <= 16; i++) {
+      if (i == 1) {
+        var data = blData[i];
+      } else {
+        // append the data
+        for (const feature of blData[i].features) {
+          data.features.push(feature);
+        }
       }
     }
   }
   return data;
+}
+
+export function shouldUseAlternateDataSource(datenstand: Date): boolean {
+  const now = new Date();
+  const nowTime = now.getTime();
+  const actualDate = now.setHours(0, 0, 0, 0);
+  const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
+  const datenstandMs = datenstand.getTime();
+  return (
+    actualDate - datenstandMs > 24 * 60 * 60000 ||
+    (datenstandMs != actualDate && nowTime > threeOclock)
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { rejects } from "assert";
 import axios, { AxiosPromise, AxiosResponse } from "axios";
 
 export function getStateAbbreviationById(id: number): string | null {
@@ -262,8 +263,20 @@ export async function getAlternateDataSource(url: string, blId?: string) {
   }
   // else download all 16 state data
   else {
+    const blPromise = [];
     const blData = [];
+    // build Promises
+    for (let i = 0; i <= 15; i++) {
+      blPromise[i] = new Promise(async (resolve) => {
+        const id = (i + 1).toString().padStart(2, "0");
+        const blUrl = url.replace("Covid19_hubv", `Covid19_${id}_hubv`);
+        axios.get(blUrl).then((response) => {
+          resolve(response.data);
+        });
+      });
+    }
     [
+      blData[0],
       blData[1],
       blData[2],
       blData[3],
@@ -279,97 +292,29 @@ export async function getAlternateDataSource(url: string, blId?: string) {
       blData[13],
       blData[14],
       blData[15],
-      blData[16],
     ] = await Promise.all([
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_01_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_02_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_03_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_04_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_05_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_06_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_07_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_08_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_09_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_10_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_11_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_12_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_13_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_14_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_15_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
-      axios
-        .get(url.replace("Covid19_hubv", `Covid19_16_hubv`))
-        .then((response) => {
-          return response.data;
-        }),
+      blPromise[0],
+      blPromise[1],
+      blPromise[2],
+      blPromise[3],
+      blPromise[4],
+      blPromise[5],
+      blPromise[6],
+      blPromise[7],
+      blPromise[8],
+      blPromise[9],
+      blPromise[10],
+      blPromise[11],
+      blPromise[12],
+      blPromise[13],
+      blPromise[14],
+      blPromise[15],
     ]);
-    for (let i = 1; i <= 16; i++) {
-      if (i == 1) {
-        var data = blData[i];
-      } else {
-        // append the data
-        for (const feature of blData[i].features) {
-          data.features.push(feature);
-        }
+    var data = blData[0];
+    for (let i = 1; i <= 15; i++) {
+      // append the data
+      for (const feature of blData[i].features) {
+        data.features.push(feature);
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 export function getStateAbbreviationById(id: number): string | null {
   switch (id) {
     case 1:
@@ -232,4 +234,46 @@ export class RKIError extends Error {
     this.rkiError = error;
     this.url = url;
   }
+}
+
+export function parseDate(dateString: string): Date {
+  const parts = dateString.split(",");
+  const dateParts = parts[0].split(".");
+  const timeParts = parts[1].replace("Uhr", "").split(":");
+  return new Date(
+    parseInt(dateParts[2]),
+    parseInt(dateParts[1]) - 1,
+    parseInt(dateParts[0]),
+    parseInt(timeParts[0]),
+    parseInt(timeParts[1])
+  );
+}
+
+export async function getDataAlternateSource(url: string, blId?: string) {
+  // If a specific table is given download this state data only
+  let stateIdList = [];
+  for (let id = 1; id <= 16; id++) {
+    stateIdList[id - 1] = id.toString().padStart(2, "0");
+  }
+  if (blId && stateIdList.includes(blId)) {
+    const urlOne = url.replace("Covid19_hubv", `Covid19_${blId}_hubv`);
+    const response = await axios.get(urlOne);
+    var data = response.data;
+  }
+  // else download all 16 state data
+  else {
+    const urlOne = url.replace("Covid19_hubv", "Covid19_01_hubv");
+    let response = await axios.get(urlOne);
+    var data = response.data;
+    for (let i = 2; i <= 16; i++) {
+      const id = i.toString().padStart(2, "0");
+      const urlX = url.replace("Covid19_hubv", `Covid19_${id}_hubv`);
+      response = await axios.get(urlX);
+      // append the data
+      for (const feature of response.data.features) {
+        data.features.push(feature);
+      }
+    }
+  }
+  return data;
 }


### PR DESCRIPTION
add the single states data source tables as backup if the main table is not updated (as the last 2 days)
the backup is only used if the main data table is not updated!
In the past I have seen similar failures that the separate data tables (for each federal state individually) were usually not affected! 

- moved also the function `parseDate()` from data-requests/districts.ts to utils.ts because this function is also needed in data-request/states.ts and data-requests/germany.ts
- add the function `getDataAlternateSource()` witch will do the requests for the single data tables.

Fix #415 