### PR TITLE
new version of the 0cases Bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "prettier": "2.4.1",
         "typescript": "^4.4.4",
         "vuepress": "^1.9.5"
+      },
+      "engines": {
+        "node": ">=16.0.0 <17"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/responses/districts.ts
+++ b/src/responses/districts.ts
@@ -125,7 +125,7 @@ export async function DistrictsCasesHistoryResponse(
     );
   }
   if (!ags && days) {
-    // if ags is not defined restrict days to 36
+    // if ags is not defined restrict days to 336
     days = Math.min(days, 336);
   } else if (!ags) {
     days = 336;
@@ -223,7 +223,7 @@ export async function DistrictsDeathsHistoryResponse(
     );
   }
   if (!ags && days) {
-    // if ags is not defined restrict days to 36
+    // if ags is not defined restrict days to 330
     days = Math.min(days, 330);
   } else if (!ags) {
     days = 330;

--- a/src/responses/districts.ts
+++ b/src/responses/districts.ts
@@ -16,6 +16,7 @@ import {
   getStateAbbreviationByName,
   fill0CasesDays,
   RequestType,
+  RegionType,
 } from "../utils";
 import {
   DistrictsFrozenIncidenceData,
@@ -138,6 +139,7 @@ export async function DistrictsCasesHistoryResponse(
     districtsHistoryData,
     lowDate,
     highDate,
+    RegionType.distrits,
     RequestType.cases
   );
   return {
@@ -236,6 +238,7 @@ export async function DistrictsDeathsHistoryResponse(
     districtsHistoryData,
     lowDate,
     highDate,
+    RegionType.distrits,
     RequestType.deaths
   );
 
@@ -273,6 +276,7 @@ export async function DistrictsRecoveredHistoryResponse(
     districtsHistoryData,
     lowDate,
     highDate,
+    RegionType.distrits,
     RequestType.recovered
   );
 

--- a/src/responses/districts.ts
+++ b/src/responses/districts.ts
@@ -13,8 +13,9 @@ import {
 } from "../data-requests/districts";
 import {
   AddDaysToDate,
-  getDayDifference,
   getStateAbbreviationByName,
+  fill0CasesDays,
+  RequestType,
 } from "../utils";
 import {
   DistrictsFrozenIncidenceData,
@@ -84,7 +85,7 @@ export async function DistrictsResponse(ags?: string): Promise<DistrictsData> {
     };
   });
 
-  if (ags != null) {
+  if (ags) {
     districts = districts.filter((districts) => {
       return districts.ags == ags;
     });
@@ -117,52 +118,31 @@ export async function DistrictsCasesHistoryResponse(
   days?: number,
   ags?: string
 ): Promise<DistrictsHistoryData<DistrictsCasesHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
-  const statesHistoryData = await getLastDistrictCasesHistory(days, ags);
-
-  const data: DistrictsCasesHistory = {};
-
-  for (const historyData of statesHistoryData.data) {
-    if (data[historyData.ags] == null) {
-      data[historyData.ags] = {
-        ags: historyData.ags,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[historyData.ags].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[historyData.ags].history[
-            data[historyData.ags].history.length - 1
-          ].date
-        ) > 1
-      ) {
-        data[historyData.ags].history.push({
-          cases: 0,
-          date: AddDaysToDate(
-            data[historyData.ags].history[
-              data[historyData.ags].history.length - 1
-            ].date,
-            1
-          ),
-        });
-      }
-    }
-    data[historyData.ags].history.push({
-      cases: historyData.cases,
-      date: new Date(historyData.date),
-    });
+  if (!ags && days) {
+    // if ags is not defined restrict days to 36
+    days = Math.min(days, 336);
+  } else if (!ags) {
+    days = 336;
   }
+  const districtsHistoryData = await getLastDistrictCasesHistory(days, ags);
+  const highDate = AddDaysToDate(districtsHistoryData.lastUpdate, -1); //highest date, if all datasets are actual, this is yesterday!
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set
+  const data: DistrictsCasesHistory = fill0CasesDays(
+    districtsHistoryData,
+    lowDate,
+    highDate,
+    RequestType.cases
+  );
   return {
     data,
-    meta: new ResponseMeta(statesHistoryData.lastUpdate),
+    meta: new ResponseMeta(districtsHistoryData.lastUpdate),
   };
 }
 
@@ -173,18 +153,18 @@ export async function DistrictsWeekIncidenceHistoryResponse(
   days?: number,
   ags?: string
 ): Promise<DistrictsHistoryData<DistrictsWeekIncidenceHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
 
   // add 6 days to calculate week incidence
-  if (days != null) {
+  if (days) {
     days += 6;
   }
 
-  const statesHistoryData = await getLastDistrictCasesHistory(days, ags);
+  const districtsHistoryData = await DistrictsCasesHistoryResponse(days, ags);
   const districtsData = await getDistrictsData();
 
   function getDistrictByAGS(
@@ -197,47 +177,10 @@ export async function DistrictsWeekIncidenceHistoryResponse(
     return null;
   }
 
-  const data: DistrictsCasesHistory = {};
-
-  for (const historyData of statesHistoryData.data) {
-    if (data[historyData.ags] == null) {
-      data[historyData.ags] = {
-        ags: historyData.ags,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[historyData.ags].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[historyData.ags].history[
-            data[historyData.ags].history.length - 1
-          ].date
-        ) > 1
-      ) {
-        data[historyData.ags].history.push({
-          cases: 0,
-          date: AddDaysToDate(
-            data[historyData.ags].history[
-              data[historyData.ags].history.length - 1
-            ].date,
-            1
-          ),
-        });
-      }
-    }
-    data[historyData.ags].history.push({
-      cases: historyData.cases,
-      date: new Date(historyData.date),
-    });
-  }
-
   const incidenceData: DistrictsWeekIncidenceHistory = {};
 
-  for (const ags of Object.keys(data)) {
-    const districtHistory = data[ags].history;
+  for (const ags of Object.keys(districtsHistoryData.data)) {
+    const districtHistory = districtsHistoryData.data[ags].history;
     const district = getDistrictByAGS(districtsData, ags);
 
     incidenceData[ags] = {
@@ -261,7 +204,7 @@ export async function DistrictsWeekIncidenceHistoryResponse(
 
   return {
     data: incidenceData,
-    meta: new ResponseMeta(statesHistoryData.lastUpdate),
+    meta: districtsHistoryData.meta,
   };
 }
 
@@ -272,52 +215,33 @@ export async function DistrictsDeathsHistoryResponse(
   days?: number,
   ags?: string
 ): Promise<DistrictsHistoryData<DistrictsDeathsHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
-  const statesHistoryData = await getLastDistrictDeathsHistory(days, ags);
-
-  const data: DistrictsDeathsHistory = {};
-
-  for (const historyData of statesHistoryData.data) {
-    if (data[historyData.ags] == null) {
-      data[historyData.ags] = {
-        ags: historyData.ags,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[historyData.ags].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[historyData.ags].history[
-            data[historyData.ags].history.length - 1
-          ].date
-        ) > 1
-      ) {
-        data[historyData.ags].history.push({
-          deaths: 0,
-          date: AddDaysToDate(
-            data[historyData.ags].history[
-              data[historyData.ags].history.length - 1
-            ].date,
-            1
-          ),
-        });
-      }
-    }
-    data[historyData.ags].history.push({
-      deaths: historyData.deaths,
-      date: new Date(historyData.date),
-    });
+  if (!ags && days) {
+    // if ags is not defined restrict days to 36
+    days = Math.min(days, 330);
+  } else if (!ags) {
+    days = 330;
   }
+  const districtsHistoryData = await getLastDistrictDeathsHistory(days, ags);
+  const highDate = AddDaysToDate(districtsHistoryData.lastUpdate, -1); //highest date, if all datasets are actual, this is yesterday!
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set
+
+  const data: DistrictsDeathsHistory = fill0CasesDays(
+    districtsHistoryData,
+    lowDate,
+    highDate,
+    RequestType.deaths
+  );
+
   return {
     data,
-    meta: new ResponseMeta(statesHistoryData.lastUpdate),
+    meta: new ResponseMeta(districtsHistoryData.lastUpdate),
   };
 }
 
@@ -328,52 +252,33 @@ export async function DistrictsRecoveredHistoryResponse(
   days?: number,
   ags?: string
 ): Promise<DistrictsHistoryData<DistrictsRecoveredHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
-  const statesHistoryData = await getLastDistrictRecoveredHistory(days, ags);
-
-  const data: DistrictsRecoveredHistory = {};
-
-  for (const historyData of statesHistoryData.data) {
-    if (data[historyData.ags] == null) {
-      data[historyData.ags] = {
-        ags: historyData.ags,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[historyData.ags].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[historyData.ags].history[
-            data[historyData.ags].history.length - 1
-          ].date
-        ) > 1
-      ) {
-        data[historyData.ags].history.push({
-          recovered: 0,
-          date: AddDaysToDate(
-            data[historyData.ags].history[
-              data[historyData.ags].history.length - 1
-            ].date,
-            1
-          ),
-        });
-      }
-    }
-    data[historyData.ags].history.push({
-      recovered: historyData.recovered,
-      date: new Date(historyData.date),
-    });
+  if (!ags && days) {
+    // if ags is not defined restrict days to 330
+    days = Math.min(days, 330);
+  } else if (!ags) {
+    days = 330;
   }
+  const districtsHistoryData = await getLastDistrictRecoveredHistory(days, ags);
+  const highDate = AddDaysToDate(districtsHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
+
+  const data: DistrictsRecoveredHistory = fill0CasesDays(
+    districtsHistoryData,
+    lowDate,
+    highDate,
+    RequestType.recovered
+  );
+
   return {
     data,
-    meta: new ResponseMeta(statesHistoryData.lastUpdate),
+    meta: new ResponseMeta(districtsHistoryData.lastUpdate),
   };
 }
 

--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -18,11 +18,14 @@ import {
   getHospitalizationData,
   getLatestHospitalizationDataKey,
 } from "../data-requests/hospitalization";
+import { getStatesFrozenIncidenceHistory } from "../data-requests/frozen-incidence";
 import {
-  getStatesFrozenIncidenceHistory,
-  StatesFrozenIncidenceData,
-} from "../data-requests/frozen-incidence";
-import { getDateBefore } from "../utils";
+  getDateBefore,
+  AddDaysToDate,
+  getDayDifference,
+  RequestType,
+  fill0CasesDaysGermany,
+} from "../utils";
 
 interface GermanyData extends IResponseMeta {
   cases: number;
@@ -134,8 +137,18 @@ export async function GermanyCasesHistoryResponse(
   days?: number
 ): Promise<GermanyHistoryData<{ cases: number; date: Date }>> {
   const history = await getLastCasesHistory(days);
+  const highDate = AddDaysToDate(history.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
+  const data = fill0CasesDaysGermany(
+    history,
+    lowDate,
+    highDate,
+    RequestType.cases
+  );
   return {
-    data: history.history,
+    data: data,
     meta: new ResponseMeta(history.lastUpdate),
   };
 }
@@ -147,7 +160,7 @@ export async function GermanyWeekIncidenceHistoryResponse(
     days += 6;
   }
 
-  const history = await getLastCasesHistory(days);
+  const history = await GermanyCasesHistoryResponse(days);
   const statesData = await getStatesData();
 
   const population = statesData.data
@@ -156,11 +169,11 @@ export async function GermanyWeekIncidenceHistoryResponse(
 
   const weekIncidenceHistory: { weekIncidence: number; date: Date }[] = [];
 
-  for (let i = 6; i < history.history.length; i++) {
-    const date = history[i].date;
+  for (let i = 6; i < history.data.length; i++) {
+    const date = history.data[i].date;
     let sum = 0;
     for (let dayOffset = i; dayOffset > i - 7; dayOffset--) {
-      sum += history[dayOffset].cases;
+      sum += history.data[dayOffset].cases;
     }
     weekIncidenceHistory.push({
       weekIncidence: (sum / population) * 100000,
@@ -170,7 +183,7 @@ export async function GermanyWeekIncidenceHistoryResponse(
 
   return {
     data: weekIncidenceHistory,
-    meta: new ResponseMeta(history.lastUpdate),
+    meta: history.meta,
   };
 }
 
@@ -178,8 +191,18 @@ export async function GermanyDeathsHistoryResponse(
   days?: number
 ): Promise<GermanyHistoryData<{ deaths: number; date: Date }>> {
   const history = await getLastDeathsHistory(days);
+  const highDate = AddDaysToDate(history.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
+  const data = fill0CasesDaysGermany(
+    history,
+    lowDate,
+    highDate,
+    RequestType.deaths
+  );
   return {
-    data: history.history,
+    data: data,
     meta: new ResponseMeta(history.lastUpdate),
   };
 }
@@ -188,8 +211,18 @@ export async function GermanyRecoveredHistoryResponse(
   days?: number
 ): Promise<GermanyHistoryData<{ recovered: number; date: Date }>> {
   const history = await getLastRecoveredHistory(days);
+  const highDate = AddDaysToDate(history.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
+  const data = fill0CasesDaysGermany(
+    history,
+    lowDate,
+    highDate,
+    RequestType.recovered
+  );
   return {
-    data: history.history,
+    data: data,
     meta: new ResponseMeta(history.lastUpdate),
   };
 }

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -21,6 +21,9 @@ import {
   getStateIdByName,
   getStateNameByAbbreviation,
   getDateBefore,
+  fill0CasesDays,
+  RegionType,
+  RequestType,
 } from "../utils";
 import { ResponseData } from "../data-requests/response-data";
 import {
@@ -116,13 +119,11 @@ export async function StatesResponse(
     };
   });
 
-  if (abbreviation != null) {
-    const id = getStateIdByAbbreviation(abbreviation);
-    if (id != null) {
-      states = states.filter((state) => {
-        return state.id == id;
-      });
-    }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
+  if (id) {
+    states = states.filter((state) => {
+      return state.id == id;
+    });
   }
 
   const statesKey = {};
@@ -152,52 +153,29 @@ export async function StatesCasesHistoryResponse(
   days?: number,
   abbreviation?: string
 ): Promise<StatesHistoryData<StatesCasesHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
 
-  let id = null;
-  if (abbreviation != null) {
-    id = getStateIdByAbbreviation(abbreviation);
-  }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
 
   const statesHistoryData = await getLastStateCasesHistory(days, id);
 
-  const data: StatesCasesHistory = {};
+  const highDate = AddDaysToDate(statesHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
 
-  for (const historyData of statesHistoryData.data) {
-    const abbr = getStateAbbreviationById(historyData.id);
-    if (data[abbr] == null) {
-      data[abbr] = {
-        id: historyData.id,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[abbr].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[abbr].history[data[abbr].history.length - 1].date
-        ) > 1
-      ) {
-        data[abbr].history.push({
-          cases: 0,
-          date: AddDaysToDate(
-            data[abbr].history[data[abbr].history.length - 1].date,
-            1
-          ),
-        });
-      }
-    }
-    data[abbr].history.push({
-      cases: historyData.cases,
-      date: new Date(historyData.date),
-    });
-  }
+  const data: StatesCasesHistory = fill0CasesDays(
+    statesHistoryData,
+    lowDate,
+    highDate,
+    RegionType.states,
+    RequestType.cases
+  );
+
   return {
     data,
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
@@ -211,21 +189,18 @@ export async function StatesWeekIncidenceHistoryResponse(
   days?: number,
   abbreviation?: string
 ): Promise<StatesHistoryData<StatesWeekIncidenceHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
 
   // add 6 days to calculate week incidence
-  if (days != null) {
+  if (days) {
     days += 6;
   }
 
-  let id = null;
-  if (abbreviation != null) {
-    id = getStateIdByAbbreviation(abbreviation);
-  }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
 
   const statesHistoryData = await getLastStateCasesHistory(days, id);
   const statesData = await getStatesData();
@@ -239,40 +214,18 @@ export async function StatesWeekIncidenceHistoryResponse(
     }
     return null;
   }
+  const highDate = AddDaysToDate(statesHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
 
-  const data: StatesCasesHistory = {};
-
-  for (const historyData of statesHistoryData.data) {
-    const abbr = getStateAbbreviationById(historyData.id);
-    if (data[abbr] == null) {
-      data[abbr] = {
-        id: historyData.id,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[abbr].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[abbr].history[data[abbr].history.length - 1].date
-        ) > 1
-      ) {
-        data[abbr].history.push({
-          cases: 0,
-          date: AddDaysToDate(
-            data[abbr].history[data[abbr].history.length - 1].date,
-            1
-          ),
-        });
-      }
-    }
-    data[abbr].history.push({
-      cases: historyData.cases,
-      date: new Date(historyData.date),
-    });
-  }
+  const data: StatesCasesHistory = fill0CasesDays(
+    statesHistoryData,
+    lowDate,
+    highDate,
+    RegionType.states,
+    RequestType.cases
+  );
 
   const incidenceData: StatesWeekIncidenceHistory = {};
 
@@ -312,52 +265,28 @@ export async function StatesDeathsHistoryResponse(
   days?: number,
   abbreviation?: string
 ): Promise<StatesHistoryData<StatesDeathsHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
 
-  let id = null;
-  if (abbreviation != null) {
-    id = getStateIdByAbbreviation(abbreviation);
-  }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
 
   const statesHistoryData = await getLastStateDeathsHistory(days, id);
+  const highDate = AddDaysToDate(statesHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
 
-  const data: StatesDeathsHistory = {};
+  const data: StatesDeathsHistory = fill0CasesDays(
+    statesHistoryData,
+    lowDate,
+    highDate,
+    RegionType.states,
+    RequestType.deaths
+  );
 
-  for (const historyData of statesHistoryData.data) {
-    const abbr = getStateAbbreviationById(historyData.id);
-    if (data[abbr] == null) {
-      data[abbr] = {
-        id: historyData.id,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[abbr].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[abbr].history[data[abbr].history.length - 1].date
-        ) > 1
-      ) {
-        data[abbr].history.push({
-          deaths: 0,
-          date: AddDaysToDate(
-            data[abbr].history[data[abbr].history.length - 1].date,
-            1
-          ),
-        });
-      }
-    }
-    data[abbr].history.push({
-      deaths: historyData.deaths,
-      date: new Date(historyData.date),
-    });
-  }
   return {
     data,
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
@@ -371,52 +300,28 @@ export async function StatesRecoveredHistoryResponse(
   days?: number,
   abbreviation?: string
 ): Promise<StatesHistoryData<StatesRecoveredHistory>> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
   }
 
-  let id = null;
-  if (abbreviation != null) {
-    id = getStateIdByAbbreviation(abbreviation);
-  }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
 
   const statesHistoryData = await getLastStateRecoveredHistory(days, id);
+  const highDate = AddDaysToDate(statesHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
+  const lowDate = days
+    ? AddDaysToDate(highDate, (days - 1) * -1)
+    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
 
-  const data: StatesRecoveredHistory = {};
+  const data: StatesRecoveredHistory = fill0CasesDays(
+    statesHistoryData,
+    lowDate,
+    highDate,
+    RegionType.states,
+    RequestType.recovered
+  );
 
-  for (const historyData of statesHistoryData.data) {
-    const abbr = getStateAbbreviationById(historyData.id);
-    if (data[abbr] == null) {
-      data[abbr] = {
-        id: historyData.id,
-        name: historyData.name,
-        history: [],
-      };
-    }
-    if (data[abbr].history.length > 0) {
-      const nextDate = new Date(historyData.date);
-      while (
-        getDayDifference(
-          nextDate,
-          data[abbr].history[data[abbr].history.length - 1].date
-        ) > 1
-      ) {
-        data[abbr].history.push({
-          recovered: 0,
-          date: AddDaysToDate(
-            data[abbr].history[data[abbr].history.length - 1].date,
-            1
-          ),
-        });
-      }
-    }
-    data[abbr].history.push({
-      recovered: historyData.recovered,
-      date: new Date(historyData.date),
-    });
-  }
   return {
     data,
     meta: new ResponseMeta(statesHistoryData.lastUpdate),
@@ -454,7 +359,7 @@ export async function StatesHospitalizationHistoryResponse(
   days?: number,
   p_abbreviation?: string
 ): Promise<StatesHospitalizationHistory> {
-  if (days != null && isNaN(days)) {
+  if (days && isNaN(days)) {
     throw new TypeError(
       "Wrong format for ':days' parameter! This is not a number."
     );
@@ -587,10 +492,8 @@ export async function StatesAgeGroupsResponse(abbreviation?: string): Promise<{
   data: AgeGroupsData;
   meta: ResponseMeta;
 }> {
-  let id = null;
-  if (abbreviation != null) {
-    id = getStateIdByAbbreviation(abbreviation);
-  }
+  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
+
   const AgeGroupsData = await getStatesAgeGroups(id);
   const hospitalizationData = await getHospitalizationData();
 

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -14,7 +14,6 @@ import {
 } from "../data-requests/states";
 import {
   AddDaysToDate,
-  getDayDifference,
   getStateAbbreviationById,
   getStateAbbreviationByName,
   getStateIdByAbbreviation,
@@ -200,9 +199,7 @@ export async function StatesWeekIncidenceHistoryResponse(
     days += 6;
   }
 
-  const id = abbreviation ? getStateIdByAbbreviation(abbreviation) : null;
-
-  const statesHistoryData = await getLastStateCasesHistory(days, id);
+  const statesHistoryCasesData = await StatesCasesHistoryResponse(days, abbreviation);
   const statesData = await getStatesData();
 
   function getStateById(
@@ -214,23 +211,11 @@ export async function StatesWeekIncidenceHistoryResponse(
     }
     return null;
   }
-  const highDate = AddDaysToDate(statesHistoryData.lastUpdate, -1); //highest date, witch is "datenstand" -1
-  const lowDate = days
-    ? AddDaysToDate(highDate, (days - 1) * -1)
-    : new Date("2020-01-01"); // lowest date if days is set, else set lowdate to 2020-01-01
-
-  const data: StatesCasesHistory = fill0CasesDays(
-    statesHistoryData,
-    lowDate,
-    highDate,
-    RegionType.states,
-    RequestType.cases
-  );
-
+  
   const incidenceData: StatesWeekIncidenceHistory = {};
 
-  for (const abbr of Object.keys(data)) {
-    const stateHistory = data[abbr].history;
+  for (const abbr of Object.keys(statesHistoryCasesData.data)) {
+    const stateHistory = statesHistoryCasesData.data[abbr].history;
     const state = getStateById(statesData, getStateIdByAbbreviation(abbr));
 
     incidenceData[abbr] = {
@@ -254,7 +239,7 @@ export async function StatesWeekIncidenceHistoryResponse(
 
   return {
     data: incidenceData,
-    meta: new ResponseMeta(statesHistoryData.lastUpdate),
+    meta: statesHistoryCasesData.meta,
   };
 }
 

--- a/src/responses/states.ts
+++ b/src/responses/states.ts
@@ -199,7 +199,10 @@ export async function StatesWeekIncidenceHistoryResponse(
     days += 6;
   }
 
-  const statesHistoryCasesData = await StatesCasesHistoryResponse(days, abbreviation);
+  const statesHistoryCasesData = await StatesCasesHistoryResponse(
+    days,
+    abbreviation
+  );
   const statesData = await getStatesData();
 
   function getStateById(
@@ -211,7 +214,7 @@ export async function StatesWeekIncidenceHistoryResponse(
     }
     return null;
   }
-  
+
   const incidenceData: StatesWeekIncidenceHistory = {};
 
   for (const abbr of Object.keys(statesHistoryCasesData.data)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
-import { rejects } from "assert";
-import axios, { AxiosPromise, AxiosResponse } from "axios";
+import axios from "axios";
 
 export function getStateAbbreviationById(id: number): string | null {
   switch (id) {
@@ -276,22 +275,100 @@ export async function getAlternateDataSource(url: string, blId?: string) {
     var data = blData[0];
     for (let i = 1; i <= 15; i++) {
       // append the data
-      for (const feature of blData[i].features) {
-        data.features.push(feature);
-      }
+      // 3 times faster than the for loop
+      data.features.push.apply(data.features, blData[i].features);
     }
   }
   return data;
 }
 
-export function shouldUseAlternateDataSource(datenstand: Date): boolean {
+export function shouldUseAlternateDataSource(
+  datenstand: Date,
+  exceededTransferLimit = false
+): boolean {
   const now = new Date();
   const nowTime = now.getTime();
   const actualDate = now.setHours(0, 0, 0, 0);
   const threeOclock = now.setHours(3, 30, 0, 0); // after 3:30 GMT the RKI data update should be done
   const datenstandMs = datenstand.getTime();
   return (
+    exceededTransferLimit ||
     actualDate - datenstandMs > 24 * 60 * 60000 ||
     (datenstandMs != actualDate && nowTime > threeOclock)
   );
+}
+
+export enum RequestType {
+  cases = "cases",
+  recovered = "recovered",
+  deaths = "deaths",
+}
+
+export function fill0CasesDays(
+  sourceData: any,
+  lowDate: Date,
+  highDate: Date,
+  requestType: RequestType
+) {
+  const targetData = {};
+  for (const historyData of sourceData.data) {
+    if (!targetData[historyData.ags]) {
+      targetData[historyData.ags] = {
+        ags: historyData.ags,
+        name: historyData.name,
+        history: [],
+      };
+    }
+    // if history is empty and lowDate is missing insert lowDate
+    if (
+      historyData.date > lowDate &&
+      targetData[historyData.ags].history.length == 0
+    ) {
+      targetData[historyData.ags].history.push({
+        [requestType]: 0,
+        date: lowDate,
+      });
+    }
+    if (targetData[historyData.ags].history.length > 0) {
+      const nextDate = new Date(historyData.date);
+      while (
+        getDayDifference(
+          nextDate,
+          targetData[historyData.ags].history[
+            targetData[historyData.ags].history.length - 1
+          ].date
+        ) > 1
+      ) {
+        targetData[historyData.ags].history.push({
+          [requestType]: 0,
+          date: AddDaysToDate(
+            targetData[historyData.ags].history[
+              targetData[historyData.ags].history.length - 1
+            ].date,
+            1
+          ),
+        });
+      }
+    }
+    targetData[historyData.ags].history.push({
+      [requestType]: historyData[requestType],
+      date: new Date(historyData.date),
+    });
+  }
+  // now fill top dates to highDate (datenstand -1) for each ags
+  for (const ags of Object.keys(targetData)) {
+    while (
+      targetData[ags].history[targetData[ags].history.length - 1].date <
+      highDate
+    ) {
+      targetData[ags].history.push({
+        [requestType]: 0,
+        date: AddDaysToDate(
+          targetData[ags].history[targetData[ags].history.length - 1].date,
+          1
+        ),
+      });
+    }
+  }
+  return targetData;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -340,7 +340,7 @@ export function fill0CasesDays(
       });
     }
     if (targetData[regionKey].history.length > 0) {
-      const nextDate = new Date(historyData.date);
+      const nextDate: Date = historyData.date;
       while (
         getDayDifference(
           nextDate,
@@ -362,7 +362,7 @@ export function fill0CasesDays(
     }
     targetData[regionKey].history.push({
       [requestType]: historyData[requestType],
-      date: new Date(historyData.date),
+      date: historyData.date,
     });
   }
   // now fill top dates to highDate (datenstand -1) for each ags
@@ -381,6 +381,47 @@ export function fill0CasesDays(
         ),
       });
     }
+  }
+  return targetData;
+}
+
+export function fill0CasesDaysGermany(
+  sourceData: any,
+  lowDate: Date,
+  highDate: Date,
+  requestType: RequestType
+) {
+  const targetData = [];
+  for (const historyData of sourceData.history) {
+    // if history is empty and lowDate is missing insert lowDate
+    if (historyData.date > lowDate && targetData.length == 0) {
+      targetData.push({
+        [requestType]: 0,
+        date: lowDate,
+      });
+    }
+    if (targetData.length > 0) {
+      const nextDate = historyData.date;
+      while (
+        getDayDifference(nextDate, targetData[targetData.length - 1].date) > 1
+      ) {
+        targetData.push({
+          [requestType]: 0,
+          date: AddDaysToDate(targetData[targetData.length - 1].date, 1),
+        });
+      }
+    }
+    targetData.push({
+      [requestType]: historyData[requestType],
+      date: historyData.date,
+    });
+  }
+  // now fill top dates to highDate (datenstand -1) for each ags
+  while (targetData[targetData.length - 1].date < highDate) {
+    targetData.push({
+      [requestType]: 0,
+      date: AddDaysToDate(targetData[targetData.length - 1].date, 1),
+    });
   }
   return targetData;
 }


### PR DESCRIPTION
This is the new version to fix the 0Cases Bug as a replacement for #241 
also i pushed the limits for districts history requests from 30 (36) to 330 (336). For separate districts there is no limits. All historys now begin at 2020-01-01.
There is no dataset in RKI database if a specific date has no cases, deaths and recovered (that meens they are "0"!
So also the weekincidence is not calculated if minumum the last day has no entry respectively at this days are "0" new cases.
This is described and discussed in #82
This patch will add the missing entrys after checking if the data is updated by checking the field "Datenstand" witch is added to the requests.
Fix #82
Fix #123
Fix #231

to do`s

- [x] add 0Cases fill for states (start and end!)
- [x] add 0Cases fill for germany (start and end)