### PR TITLE
Add states germany vaccination

### DIFF
--- a/docs/endpoints/vaccinations.md
+++ b/docs/endpoints/vaccinations.md
@@ -151,12 +151,10 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
 
 ```json
 {
-  "data":
-  {
+  "data": {
     "administeredVaccinations":178553363,
     "vaccinated":64498951,
-    "vaccination":
-    {
+    "vaccination": {
       "biontech":46309524,
       "moderna":5108082,
       "astraZeneca":9336101,
@@ -170,26 +168,22 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
     },
     "delta":1429,
     "quote":0.776,
-    "quotes":{
+    "quotes": {
       "total":0.776,
-      "A05-A17":
-      {
+      "A05-A17": {
         "total":0.452,
         "A05-A11":0.22,
         "A12-A17":0.722
       },
-      "A18+":
-      {
+      "A18+": {
         "total":0.866,
         "A18-A59":0.833,
         "A60+":0.916
       }
     },
-    "secondVaccination":
-    {
+    "secondVaccination": {
       "vaccinated":63010774,
-      "vaccination":
-      {
+      "vaccination": {
         "biontech":50805150,
         "moderna":6342278,
         "astraZeneca":3533141,
@@ -203,27 +197,22 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
       },
       "delta":3207,
       "quote":0.758,
-      "quotes":
-      {
+      "quotes": {
         "total":0.758,
-        "A05-A17":
-        {
+        "A05-A17": {
           "total":0.411,
           "A05-A11":0.193,
           "A12-A17":0.665},
-          "A18+":
-          {
+          "A18+": {
             "total":0.85,
             "A18-A59":0.819,
             "A60+":0.908
           }
         }
       },
-      "boosterVaccination":
-      {
+      "boosterVaccination": {
         "vaccinated":49318858,
-        "vaccination":
-        {
+        "vaccination": {
           "biontech":31176173,
           "moderna":18115596,
           "astraZeneca":6175,
@@ -237,28 +226,23 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
         },
         "delta":7489,
         "quote":0.593,
-        "quotes":
-        {
+        "quotes": {
           "total":0.593,
-          "A05-A17":
-          {
+          "A05-A17": {
             "total":0.307,
             "A05-A11":null,
             "A12-A17":0.307
           },
-          "A18+":
-          {
+          "A18+": {
             "total":0.689,
             "A18-A59":0.631,
             "A60+":0.797
           }
         }
       },
-      "2ndBoosterVaccination":
-      {
+      "2ndBoosterVaccination": {
         "vaccinated":3996240,
-        "vaccination":
-        {
+        "vaccination": {
           "biontech":3179117,
           "moderna":810881,
           "astraZeneca":660,
@@ -272,32 +256,26 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
         },
         "delta":14068,
         "quote":0.048,
-        "quotes":
-        {
+        "quotes": {
           "total":0.048,
-          "A05-A17":
-          {
+          "A05-A17": {
             "total":0.003,
             "A05-A11":null,
             "A12-A17":0.003
           },
-          "A18+":
-          {
+          "A18+": {
             "total":0.059,
             "A18-A59":0.013,
             "A60+":0.147
           }
         }
       },
-      "states":
-      {
-        "SH":
-        {
+      "states": {
+        "SH": {
           "name":"Schleswig-Holstein",
           "administeredVaccinations":6864557,
           "vaccinated":2351695,
-          "vaccination":
-          {
+          "vaccination": {
             "biontech":1661525,
             "moderna":189976,
             "astraZeneca":363254,
@@ -311,27 +289,22 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
           },
           "delta":40,
           "quote":0.808,
-          "quotes":
-          {
+          "quotes": {
             "total":0.808,
-            "A05-A17":
-            {
+            "A05-A17": {
               "total":0.596,
               "A05-A11":0.302,
               "A12-A17":0.924
             },
-            "A18+":
-            {
+            "A18+": {
               "total":0.884,
               "A18-A59":0.851,
               "A60+":0.938
             }
           },
-          "secondVaccination":
-          {
+          "secondVaccination": {
             "vaccinated":2318092,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":1836165,
               "moderna":249723,
               "astraZeneca":156907,
@@ -345,28 +318,23 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":127,
             "quote":0.796,
-            "quotes":
-            {
+            "quotes": {
               "total":0.796,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":0.557,
                 "A05-A11":0.289,
                 "A12-A17":0.856
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":0.877,
                 "A18-A59":0.848,
                 "A60+":0.929
               }
             }
           },
-          "boosterVaccination":
-          {
+          "boosterVaccination": {
             "vaccinated":2107324,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":1227875,
               "moderna":877821,
               "janssen":1394,
@@ -380,28 +348,23 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":352,
             "quote":0.724,
-            "quotes":
-            {
+            "quotes": {
               "total":0.724,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":0.436,
                 "A05-A11":null,
                 "A12-A17":0.436
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":0.785,
                 "A18-A59":0.719,
                 "A60+":0.902
               }
             }
           },
-          "2ndBoosterVaccination":
-          {
+          "2ndBoosterVaccination": {
             "vaccinated":160350,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":97809,
               "moderna":62514,
               "janssen":null,
@@ -415,17 +378,14 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":609,
             "quote":0.055,
-            "quotes":
-            {
+            "quotes": {
               "total":0.055,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":0.002,
                 "A05-A11":null,
                 "A12-A17":0.002
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":0.117,
                 "A18-A59":0.017,
                 "A60+":0.017
@@ -434,13 +394,11 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
           }
         },
         ...
-        "Bund":
-        {
+        "Bund": {
           "name":"Bundesressorts",
           "administeredVaccinations":533493,
           "vaccinated":201886,
-          "vaccination":
-          {
+          "vaccination": {
             "biontech":90037,
             "moderna":83293,
             "astraZeneca":20400,
@@ -454,27 +412,22 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
           },
           "delta":0,
           "quote":null,
-          "quotes":
-          {
+          "quotes": {
             "total":null,
-            "A05-A17":
-            {
+            "A05-A17": {
               "total":null,
               "A05-A11":null,
               "A12-A17":null
             },
-            "A18+":
-            {
+            "A18+": {
               "total":null,
               "A18-A59":null,
               "A60+":null
             }
           },
-          "secondVaccination":
-          {
+          "secondVaccination": {
             "vaccinated":189399,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":92222,
               "moderna":87247,
               "astraZeneca":9910,
@@ -488,28 +441,23 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":0,
             "quote":null,
-            "quotes":
-            {
+            "quotes": {
               "total":null,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":null,
                 "A05-A11":null,
                 "A12-A17":null
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":null,
                 "A18-A59":null,
                 "A60+":null
               }
             }
           },
-          "boosterVaccination":
-          {
+          "boosterVaccination": {
             "vaccinated":141589,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":109334,
               "moderna":32246,
               "janssen":5,
@@ -523,28 +471,23 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":0,
             "quote":null,
-            "quotes":
-            {
+            "quotes": {
               "total":null,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":null,
                 "A05-A11":null,
                 "A12-A17":null
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":null,
                 "A18-A59":null,
                 "A60+":null
               }
             }
           },
-          "2ndBoosterVaccination":
-          {
+          "2ndBoosterVaccination": {
             "vaccinated":619,
-            "vaccination":
-            {
+            "vaccination": {
               "biontech":580,
               "moderna":39,
               "janssen":null,
@@ -558,17 +501,14 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
             },
             "delta":0,
             "quote":null,
-            "quotes":
-            {
+            "quotes": {
               "total":null,
-              "A05-A17":
-              {
+              "A05-A17": {
                 "total":null,
                 "A05-A11":null,
                 "A12-A17":null
               },
-              "A18+":
-              {
+              "A18+": {
                 "total":null,
                 "A18-A59":null,
                 "A60+":null
@@ -578,14 +518,283 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
         }
       }
     },
-    "meta":
-    {
+    "meta": {
       "source":"Robert Koch-Institut",
       "contact":"Marlon Lueckert (m.lueckert@me.com)",
       "info":"https://github.com/marlon360/rki-covid-api",
       "lastUpdate":"2022-05-02T06:53:48.000Z",
       "lastCheckedForUpdate":"2022-05-02T13:10:08.247Z"
     }
+  }
+}
+```
+
+## `/vaccinations/states`
+
+### Request
+
+`GET https://api.corona-zahlen.org/vaccinations/states`
+[Open](/vaccinations/states)
+
+### Response
+
+This responses only the states data (but not all of Germany)
+
+```json
+{
+  "data": {
+    "SH": {
+      "name":"Schleswig-Holstein",
+      "administeredVaccinations":6864694,
+      "vaccinated":2351707,
+      "vaccination": {
+        "biontech":1661535,
+        "moderna":189978,
+        "astraZeneca":363254,
+        "janssen":134850,
+        "novavax":2090,
+        "deltaBiontech":10,
+        "deltaModerna":2,
+        "deltaAstraZeneca":0,
+        "deltaJanssen":0,
+        "deltaNovavax":0
+      },
+      "delta":12,
+      "quote":0.808,
+      "quotes": {
+        "total":0.808,
+        "A05-A17": {
+          "total":0.596,
+          "A05-A11":0.302,
+          "A12-A17":0.924
+        },
+        "A18+": {
+          "total":0.884,
+          "A18-A59":0.851,
+          "A60+":0.938
+        }
+      },
+      "secondVaccination": {
+        "vaccinated":2318116,
+        "vaccination": {
+          "biontech":1836187,
+          "moderna":249725,
+          "astraZeneca":156907,
+          "janssen":459,
+          "novavax":1934,
+          "deltaBiontech":22,
+          "deltaModerna":2,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":0
+        },
+        "delta":24,
+        "quote":0.796,
+        "quotes": {
+          "total":0.796,
+          "A05-A17": {
+            "total":0.557,
+            "A05-A11":0.289,
+            "A12-A17":0.856
+          },
+          "A18+": {
+            "total":0.877,
+            "A18-A59":0.848,
+            "A60+":0.929
+          }
+        }
+      },
+      "boosterVaccination": {
+        "vaccinated":2107341,
+        "vaccination": {
+          "biontech":1227891,
+          "moderna":877822,
+          "janssen":1394,
+          "astraZeneca":125,
+          "novavax":109,
+          "deltaBiontech":16,
+          "deltaModerna":1,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":0
+        },
+        "delta":17,
+        "quote":0.724,
+        "quotes": {
+          "total":0.724,
+          "A05-A17": {
+            "total":0.436,
+            "A05-A11":null,
+            "A12-A17":0.436
+          },
+          "A18+": {
+            "total":0.785,
+            "A18-A59":0.719,
+            "A60+":0.902
+          }
+        }
+      },
+      "2ndBoosterVaccination": {
+        "vaccinated":160434,
+        "vaccination": {
+          "biontech":97891,
+          "moderna":62516,
+          "janssen":null,
+          "astraZeneca":null,
+          "novavax":27,
+          "deltaBiontech":82,
+          "deltaModerna":2,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":0
+        },
+        "delta":84,
+        "quote":0.055,
+        "quotes": {
+          "total":0.055,
+          "A05-A17": {
+            "total":0.002,
+            "A05-A11":null,
+            "A12-A17":0.002
+          },
+          "A18+": {
+            "total":0.117,
+            "A18-A59":0.017,
+            "A60+":0.017
+          }
+        }
+      }
+    },
+    ...
+    "TH": {
+      "name":"Thüringen",
+      "administeredVaccinations":4069642,
+      "vaccinated":1499281,
+      "vaccination": {
+        "biontech":1089480,
+        "moderna":140934,
+        "astraZeneca":171084,
+        "janssen":95192,
+        "novavax":2591,
+        "deltaBiontech":2,
+        "deltaModerna":-10,
+        "deltaAstraZeneca":0,
+        "deltaJanssen":0,
+        "deltaNovavax":3
+      },
+      "delta":-5,
+      "quote":0.707,
+      "quotes": {
+        "total":0.707,
+        "A05-A17": {
+          "total":0.301,
+          "A05-A11":0.113,
+          "A12-A17":0.535
+        },
+        "A18+": {
+          "total":0.795,
+          "A18-A59":0.732,
+          "A60+":0.878
+        }
+      },
+      "secondVaccination": {
+        "vaccinated":1468748,
+        "vaccination": {
+          "biontech":1174437,
+          "moderna":165618,
+          "astraZeneca":78447,
+          "janssen":347,
+          "novavax":1763,
+          "deltaBiontech":37,
+          "deltaModerna":2,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":3
+        },
+        "delta":42,
+        "quote":0.693,
+        "quotes": {
+          "total":0.693,
+          "A05-A17": {
+            "total":0.287,
+            "A05-A11":0.106,
+            "A12-A17":0.512
+          },
+          "A18+": {
+            "total":0.78,
+            "A18-A59":0.711,
+            "A60+":0.878
+          }
+        }
+      },
+      "boosterVaccination": {
+        "vaccinated":1101633,
+        "vaccination": {
+          "biontech":750456,
+          "moderna":351001,
+          "janssen":118,
+          "astraZeneca":4,
+          "novavax":54,
+          "deltaBiontech":173,
+          "deltaModerna":14,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":2
+        },
+        "delta":189,
+        "quote":0.52,
+        "quotes": {
+          "total":0.52,
+          "A05-A17": {
+            "total":0.192,
+            "A05-A11":null,
+            "A12-A17":0.192
+          },
+          "A18+": {
+            "total":0.602,
+            "A18-A59":0.5,
+            "A60+":0.748
+          }
+        }
+      },
+      "2ndBoosterVaccination": {
+        "vaccinated":48116,
+        "vaccination": {
+          "biontech":41027,
+          "moderna":7065,
+          "janssen":5,
+          "astraZeneca":null,
+          "novavax":19,
+          "deltaBiontech":205,
+          "deltaModerna":5,
+          "deltaAstraZeneca":0,
+          "deltaJanssen":0,
+          "deltaNovavax":0
+        },
+        "delta":210,
+        "quote":0.023,
+        "quotes": {
+          "total":0.023,
+          "A05-A17": {
+            "total":0.001,
+            "A05-A11":null,
+            "A12-A17":0.001
+          },
+          "A18+": {
+            "total":0.027,
+            "A18-A59":0.008,
+            "A60+":0.008
+          }
+        }
+      }
+    }
+  },
+  "meta": {
+    "source":"Robert Koch-Institut",
+    "contact":"Marlon Lueckert (m.lueckert@me.com)",
+    "info":"https://github.com/marlon360/rki-covid-api",
+    "lastUpdate":"2022-05-03T06:53:52.000Z",
+    "lastCheckedForUpdate":"2022-05-03T20:11:08.379Z"
   }
 }
 ```
@@ -597,11 +806,293 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
 `GET https://api.corona-zahlen.org/vaccinations/states/HH`
 [Open](/vaccinations/states/HH)
 
+### Response
+
+```json
+{
+  "data": {
+    "HH": {
+      "name": "Hamburg",
+      "administeredVaccinations": 4328358,
+      "vaccinated": 1598944,
+      "vaccination": {
+        "biontech": 1153350,
+        "moderna": 129969,
+        "astraZeneca": 199211,
+        "janssen": 115180,
+        "novavax": 1234,
+        "deltaBiontech": 406,
+        "deltaModerna": 21,
+        "deltaAstraZeneca": 0,
+        "deltaJanssen": 0,
+        "deltaNovavax": 5
+      },
+      "delta": 432,
+      "quote": 0.863,
+      "quotes": {
+        "total": 0.863,
+        "A05-A17": {
+          "total": 0.509,
+          "A05-A11": 0.293,
+          "A12-A17": 0.78
+        },
+        "A18+": {
+          "total": 0.968,
+          "A18-A59": 0.958,
+          "A60+": 0.981
+        }
+      },
+      "secondVaccination": {
+        "vaccinated": 1549544,
+        "vaccination": {
+          "biontech": 1248184,
+          "moderna": 192503,
+          "astraZeneca": 44833,
+          "janssen": 511,
+          "novavax": 1042,
+          "deltaBiontech": 822,
+          "deltaModerna": 136,
+          "deltaAstraZeneca": 0,
+          "deltaJanssen": 0,
+          "deltaNovavax": 1
+        },
+        "delta": 959,
+        "quote": 0.836,
+        "quotes": {
+          "total": 0.836,
+          "A05-A17": {
+            "total": 0.448,
+            "A05-A11": 0.235,
+            "A12-A17": 0.715
+          },
+          "A18+": {
+            "total": 0.945,
+            "A18-A59": 0.933,
+            "A60+": 0.974
+          }
+        }
+      },
+      "boosterVaccination": {
+        "vaccinated": 1133020,
+        "vaccination": {
+          "biontech": 687894,
+          "moderna": 444613,
+          "janssen": 258,
+          "astraZeneca": 166,
+          "novavax": 89,
+          "deltaBiontech": 1746,
+          "deltaModerna": 328,
+          "deltaAstraZeneca": 0,
+          "deltaJanssen": 0,
+          "deltaNovavax": 1
+        },
+        "delta": 2075,
+        "quote": 0.612,
+        "quotes": {
+          "total": 0.612,
+          "A05-A17": {
+            "total": 0.286,
+            "A05-A11": null,
+            "A12-A17": 0.286
+          },
+          "A18+": {
+            "total": 0.718,
+            "A18-A59": 0.682,
+            "A60+": 0.808
+          }
+        }
+      },
+      "2ndBoosterVaccination": {
+        "vaccinated": 109321,
+        "vaccination": {
+          "biontech": 79525,
+          "moderna": 29711,
+          "janssen": 1,
+          "astraZeneca": null,
+          "novavax": 84,
+          "deltaBiontech": 1396,
+          "deltaModerna": 179,
+          "deltaAstraZeneca": 0,
+          "deltaJanssen": 0,
+          "deltaNovavax": 0
+        },
+        "delta": 1575,
+        "quote": 0.059,
+        "quotes": {
+          "total": 0.059,
+          "A05-A17": {
+            "total": 0.004,
+            "A05-A11": null,
+            "A12-A17": 0.004
+          },
+          "A18+": {
+            "total": 0.071,
+            "A18-A59": 0.019,
+            "A60+": 0.019
+          }
+        }
+      }
+    }
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2022-05-04T06:54:40.000Z",
+    "lastCheckedForUpdate": "2022-05-04T18:20:28.758Z"
+  }
+}
+```
+
 **Parameters**
 
 | Parameter | Description                         |
 | --------- | ----------------------------------- |
 | :state    | abbreviation of the requested state |
+
+## `/vaccinations/germany`
+
+### Request
+
+`GET https://api.corona-zahlen.org/vaccinations/germany`
+[Open](/vaccinations/germany)
+
+### Response
+
+This responses only the germany data
+
+```json
+{
+  "data": {
+    "administeredVaccinations": 178601338,
+    "vaccinated": 64500699,
+    "vaccination": {
+      "biontech": 46310909,
+      "moderna": 5108169,
+      "astraZeneca": 9336123,
+      "janssen": 3686224,
+      "novavax": 59274,
+      "deltaBiontech": 1385,
+      "deltaModerna": 87,
+      "deltaAstraZeneca": 22,
+      "deltaJanssen": 13,
+      "deltaNovavax": 241
+    },
+    "delta": 1748,
+    "quote": 0.776,
+    "quotes": {
+      "total": 0.776,
+      "A05-A17": {
+        "total": 0.452,
+        "A05-A11": 0.22,
+        "A12-A17": 0.722
+      },
+      "A18+": {
+        "total": 0.866,
+        "A18-A59": 0.833,
+        "A60+": 0.916
+      }
+    },
+    "secondVaccination": {
+      "vaccinated": 63014353,
+      "vaccination": {
+        "biontech": 50808120,
+        "moderna": 6342570,
+        "astraZeneca": 3533142,
+        "janssen": 10811,
+        "novavax": 48250,
+        "deltaBiontech": 2970,
+        "deltaModerna": 292,
+        "deltaAstraZeneca": 1,
+        "deltaJanssen": 5,
+        "deltaNovavax": 311
+      },
+      "delta": 3579,
+      "quote": 0.758,
+      "quotes": {
+        "total": 0.758,
+        "A05-A17": {
+          "total": 0.411,
+          "A05-A11": 0.193,
+          "A12-A17": 0.666
+        },
+        "A18+": {
+          "total": 0.85,
+          "A18-A59": 0.819,
+          "A60+": 0.908
+        }
+      }
+    },
+    "boosterVaccination": {
+      "vaccinated": 49329564,
+      "vaccination": {
+        "biontech": 31185360,
+        "moderna": 18117070,
+        "astraZeneca": 6175,
+        "janssen": 18357,
+        "novavax": 2602,
+        "deltaBiontech": 9187,
+        "deltaModerna": 1474,
+        "deltaAstraZeneca": 0,
+        "deltaJanssen": 19,
+        "deltaNovavax": 26
+      },
+      "delta": 10706,
+      "quote": 0.593,
+      "quotes": {
+        "total": 0.593,
+        "A05-A17": {
+          "total": 0.307,
+          "A05-A11": null,
+          "A12-A17": 0.307
+        },
+        "A18+": {
+          "total": 0.689,
+          "A18-A59": 0.631,
+          "A60+": 0.797
+        }
+      }
+    },
+    "2ndBoosterVaccination": {
+      "vaccinated": 4028182,
+      "vaccination": {
+        "biontech": 3205209,
+        "moderna": 816699,
+        "astraZeneca": 660,
+        "janssen": 4380,
+        "novavax": 1234,
+        "deltaBiontech": 26092,
+        "deltaModerna": 5818,
+        "deltaAstraZeneca": 0,
+        "deltaJanssen": 16,
+        "deltaNovavax": 16
+      },
+      "delta": 31942,
+      "quote": 0.048,
+      "quotes": {
+        "total": 0.048,
+        "A05-A17": {
+          "total": 0.003,
+          "A05-A11": null,
+          "A12-A17": 0.003
+        },
+        "A18+": {
+          "total": 0.06,
+          "A18-A59": 0.013,
+          "A60+": 0.148
+        }
+      }
+    }
+  },
+  "meta": {
+    "source": "Robert Koch-Institut",
+    "contact": "Marlon Lueckert (m.lueckert@me.com)",
+    "info": "https://github.com/marlon360/rki-covid-api",
+    "lastUpdate": "2022-05-03T06:53:52.000Z",
+    "lastCheckedForUpdate": "2022-05-03T20:10:44.459Z"
+  }
+}
+```
 
 ## `/vaccinations/history`
 
@@ -628,10 +1119,8 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
 
 ```json
 {
-  "data":
-  {
-    "history":
-    [
+  "data": {
+    "history": [
       {
         "date":"2020-12-27T00:00:00.000Z",
         "vaccinated":24421,
@@ -671,8 +1160,7 @@ _ATTENTION_ since 2021-04-08 the RKI dropped the indication information!
       }
     ]
   },
-  "meta":
-  {
+  "meta": {
     "source":"Robert Koch-Institut",
     "contact":"Marlon Lueckert (m.lueckert@me.com)",
     "info":"https://github.com/marlon360/rki-covid-api",

--- a/src/responses/vaccination.ts
+++ b/src/responses/vaccination.ts
@@ -5,7 +5,7 @@ import {
   getVaccinationHistory,
   VaccinationHistoryEntry,
 } from "../data-requests/vaccination";
-import { getStateAbbreviationById, } from "../utils";
+import { getStateAbbreviationById } from "../utils";
 
 interface VaccinationData extends IResponseMeta {
   data: VaccinationCoverage;

--- a/src/responses/vaccination.ts
+++ b/src/responses/vaccination.ts
@@ -5,7 +5,7 @@ import {
   getVaccinationHistory,
   VaccinationHistoryEntry,
 } from "../data-requests/vaccination";
-import { getStateAbbreviationById } from "../utils";
+import { getStateAbbreviationById, } from "../utils";
 
 interface VaccinationData extends IResponseMeta {
   data: VaccinationCoverage;
@@ -28,12 +28,20 @@ export async function VaccinationGermanyResponse(): Promise<VaccinationData> {
   };
 }
 
+function isAbbreviationValid(abbreviation: string) {
+  let abbreviationList = [];
+  for (let id = 1; id <= 16; id++) {
+    abbreviationList[id - 1] = getStateAbbreviationById(id);
+  }
+  return abbreviationList.includes(abbreviation);
+}
+
 export async function VaccinationStatesResponse(
   abbreviation?: string
 ): Promise<VaccinationData> {
   const vaccinationData = await getVaccinationCoverage();
   const vaccinationDataOut = { data: undefined };
-  if (abbreviation) {
+  if (abbreviation && isAbbreviationValid(abbreviation)) {
     const tempData = { data: undefined };
     tempData.data = {
       [abbreviation]: vaccinationData.data.states[abbreviation],

--- a/src/responses/vaccination.ts
+++ b/src/responses/vaccination.ts
@@ -5,22 +5,52 @@ import {
   getVaccinationHistory,
   VaccinationHistoryEntry,
 } from "../data-requests/vaccination";
+import { getStateAbbreviationById } from "../utils";
 
 interface VaccinationData extends IResponseMeta {
   data: VaccinationCoverage;
 }
 
-export async function VaccinationResponse(
+export async function VaccinationResponse(): Promise<VaccinationData> {
+  const vaccinationData = await getVaccinationCoverage();
+  return {
+    data: vaccinationData.data,
+    meta: new ResponseMeta(vaccinationData.lastUpdate),
+  };
+}
+
+export async function VaccinationGermanyResponse(): Promise<VaccinationData> {
+  const vaccinationData = await getVaccinationCoverage();
+  delete vaccinationData.data.states;
+  return {
+    data: vaccinationData.data,
+    meta: new ResponseMeta(vaccinationData.lastUpdate),
+  };
+}
+
+export async function VaccinationStatesResponse(
   abbreviation?: string
 ): Promise<VaccinationData> {
   const vaccinationData = await getVaccinationCoverage();
   const vaccinationDataOut = { data: undefined };
   if (abbreviation) {
-    vaccinationDataOut.data = { [abbreviation]: undefined };
-    vaccinationDataOut.data[abbreviation] =
-      vaccinationData.data.states[abbreviation];
+    const tempData = { data: undefined };
+    tempData.data = {
+      [abbreviation]: vaccinationData.data.states[abbreviation],
+    };
+    vaccinationDataOut.data = { ...vaccinationDataOut.data, ...tempData.data };
   } else {
-    vaccinationDataOut.data = vaccinationData.data;
+    for (let id = 1; id <= 16; id++) {
+      const tempData = { data: undefined };
+      tempData.data = {
+        [getStateAbbreviationById(id)]:
+          vaccinationData.data.states[getStateAbbreviationById(id)],
+      };
+      vaccinationDataOut.data = {
+        ...vaccinationDataOut.data,
+        ...tempData.data,
+      };
+    }
   }
   return {
     data: vaccinationDataOut.data,

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,8 @@ import {
 import {
   VaccinationResponse,
   VaccinationHistoryResponse,
+  VaccinationStatesResponse,
+  VaccinationGermanyResponse,
 } from "./responses/vaccination";
 import { TestingHistoryResponse } from "./responses/testing";
 import {
@@ -844,11 +846,31 @@ app.get(
 );
 
 app.get(
+  "/vaccinations/germany",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await VaccinationGermanyResponse();
+    res.json(response);
+  }
+);
+
+app.get(
+  "/vaccinations/states",
+  queuedCache(),
+  cache.route(),
+  async function (req, res) {
+    const response = await VaccinationStatesResponse(req.params.state);
+    res.json(response);
+  }
+);
+
+app.get(
   "/vaccinations/states/:state",
   queuedCache(),
   cache.route(),
   async function (req, res) {
-    const response = await VaccinationResponse(req.params.state);
+    const response = await VaccinationStatesResponse(req.params.state);
     res.json(response);
   }
 );


### PR DESCRIPTION
because of the existing  /vaccinations/states/:state
add /vaccinations/states and vaccination/germany
to make the thing round

Changes to be committed:
modified:   docs/endpoints/vaccinations.md
modified:   src/responses/vaccination.ts
modified:   src/server.ts