### PR TITLE
Update URL for r-value JSON file

### DIFF
--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -63,7 +63,7 @@ export async function getRValue() {
   const data = response.data;
   const rData = parseRValue(data);
   const meta = await axios.get(
-    `https://github.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/raw/main/.zenodo.json`
+    `https://github.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/raw/main/Metadaten/zenodo.json`
   );
   return {
     data: rData,


### PR DESCRIPTION
The URL of the `zenodo.json` file has changed with [robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung#80a163b](https://github.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/commit/80a163bf8ef9662d2ce0fb5badcd35a6c6f029a5), so this commit reflects that change.