### PR TITLE
frozen incidence daily data stored in redis is not deleted when it is no longer needed

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -7,8 +7,8 @@ import {
   getDateBefore,
   getDayDifference,
   getStateAbbreviationByName,
-  getStateIdByAbbreviation,
   RKIError,
+  getStateIdByAbbreviation,
 } from "../utils";
 import { ResponseData } from "./response-data";
 
@@ -159,18 +159,6 @@ const getJsonDataFromRedis = function (redisKey: string) {
   });
 };
 
-const delJsonDataFromRedis = function (redisKey: string) {
-  return new Promise<number>((resolve, reject) => {
-    fiJsonCache.del(redisKey, (err, deletions) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(deletions);
-      }
-    });
-  });
-};
-
 // this is a reviver for JSON.parse to convert all key including "date" to Date type
 const dateReviver = function (
   objKey: string,
@@ -266,16 +254,16 @@ const RkiFrozenIncidenceHistoryPromise = async function (resolve, reject) {
   resolve({ lastUpdate, data });
 };
 
-// this is the Promise to download the files for the missing frozen-incidence dates
+// this is the Promise to download the files or get it from redis for the missing frozen-incidence dates
 const MissingDateDataPromise = async function (resolve, reject) {
   const requestType: RequestTypeParameter = this.requestType;
   const date = this.date;
   const redisKey = `${requestType.redisKey}_${date}`;
   const githubUrlPre = requestType.githubUrlPre;
   const githubUrlPost = requestType.githubUrlPost;
-
-  const redisEntry = await getJsonDataFromRedis(redisKey);
+  
   let missingDateData: FrozenIncidenceDayFile;
+  const redisEntry = await getJsonDataFromRedis(redisKey);
   if (redisEntry.length == 1) {
     missingDateData = JSON.parse(redisEntry[0].body, dateReviver);
   } else {
@@ -289,9 +277,12 @@ const MissingDateDataPromise = async function (resolve, reject) {
     const unzipped = await new Promise((resolve) =>
       zlib.gunzip(rdata, (_, result) => resolve(result))
     );
+    // prepare data for redis
+    const redisData = unzipped.toString();
+    const validFor = (AddDaysToDate(date, 14).getTime() - new Date().getTime()) / 1000;
     // add to redis
-    await addJsonDataToRedis(redisKey, unzipped.toString(), -1);
-    missingDateData = JSON.parse(unzipped.toString(), dateReviver);
+    await addJsonDataToRedis(redisKey, redisData, validFor);
+    missingDateData = JSON.parse(redisData, dateReviver);
   }
   resolve(missingDateData);
 };
@@ -412,25 +403,6 @@ async function finalizeData(
   return { data: actualData.data, lastUpdate: lastUpdate };
 }
 
-// function to cleanup the daily missing data entry in redis
-async function CleanupRedisCache(
-  lastUpdateExcelAktuell: Date,
-  requestType: RequestTypeParameter
-) {
-  const date = new Date(lastUpdateExcelAktuell);
-  date.setHours(0, 0, 0, 0);
-  for (let i = 14; i >= 0; i--) {
-    const dateStr = AddDaysToDate(date, i).toISOString().split("T").shift();
-    const redisKey = `${dateStr}_${requestType.redisKey}`;
-    const numberOfDeletions = await delJsonDataFromRedis(redisKey);
-    if (numberOfDeletions) {
-      console.log(
-        `Rediskey ${redisKey} deleted. Number of deletions: ${numberOfDeletions}`
-      );
-    }
-  }
-}
-
 export async function getDistrictsFrozenIncidenceHistory(
   days?: number,
   ags?: string,
@@ -467,9 +439,7 @@ export async function getDistrictsFrozenIncidenceHistory(
     days,
     date
   );
-
-  await CleanupRedisCache(actual.lastUpdate, ActualDistricts);
-
+  
   return {
     data: actualFinal.data,
     lastUpdate: actualFinal.lastUpdate,
@@ -512,8 +482,6 @@ export async function getStatesFrozenIncidenceHistory(
     days,
     date
   );
-
-  await CleanupRedisCache(actual.lastUpdate, ActualStates);
 
   return {
     data: actualFinal.data,


### PR DESCRIPTION
frozen incidence daily data is now stored with a validity range of 10 days after lastUpdate by RKI.
Redis cleanup function deleted. 
Fix #496 