### PR TITLE
fix population data for germany

### DIFF
--- a/src/responses/germany.ts
+++ b/src/responses/germany.ts
@@ -191,9 +191,7 @@ export async function GermanyWeekIncidenceHistoryResponse(
   const history = await GermanyCasesHistoryResponse(days);
   const statesData = await getStatesData();
 
-  const population = statesData.data
-    .map((state) => state.population)
-    .reduce((cur, acc) => (cur += acc));
+  const population = statesData.data[0].population;
 
   const weekIncidenceHistory: { weekIncidence: number; date: Date }[] = [];
 


### PR DESCRIPTION
the population data to calculate the incidence data for germany was doubled ( ~ 166.000.000 instead of ~83.000.000)
this will fix this!
