### PR TITLE
fix missing frozen inciedence date (2023-04-11)

### DIFF
--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -343,7 +343,9 @@ async function finalizeData(
   paramDate?: Date
 ): Promise<{ data: FrozenIncidenceData[]; lastUpdate: Date }> {
   // get last date from one actualData history
-  const lastDate = new Date(actualData.data[0].history[actualData.data[0].history.length - 1].date).setHours(0, 0, 0);
+  const lastDate = new Date(
+    actualData.data[0].history[actualData.data[0].history.length - 1].date
+  ).setHours(0, 0, 0);
   const today = new Date().setHours(0, 0, 0);
   let lastUpdate: Date;
   // if lastDate < today and lastDate <= lastFileDate get the missing dates from github stored json files

--- a/src/data-requests/frozen-incidence.ts
+++ b/src/data-requests/frozen-incidence.ts
@@ -342,8 +342,8 @@ async function finalizeData(
   paramDays?: number,
   paramDate?: Date
 ): Promise<{ data: FrozenIncidenceData[]; lastUpdate: Date }> {
-  // lastUpdate from actual data is date of last entry
-  const lastDate = new Date(actualData.lastUpdate).setHours(0, 0, 0);
+  // get last date from one actualData history
+  const lastDate = new Date(actualData.data[0].history[actualData.data[0].history.length - 1].date).setHours(0, 0, 0);
   const today = new Date().setHours(0, 0, 0);
   let lastUpdate: Date;
   // if lastDate < today and lastDate <= lastFileDate get the missing dates from github stored json files


### PR DESCRIPTION
today (maybe yesterday too) the date 2023-04-11 is missing in frozen-incidence history (germany, states and districts).
the last date of the excel file was equated with the date of the last update. But that doesn't work here because the Excel file was updated on April 11, 2023, but the last date in the file was April 10, 2023. As a result, the data from April 11, 2023 was not added!
This pull request will fix this by determining the last date from the data