### PR TITLE
Change from daily files to merged files for districts and states

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,17 +479,19 @@ export function dateReviver(objKey: string, objValue: string | number | Date) {
   return objValue;
 }
 
-interface MetaData {
-  created: number;
-  modified: number;
-  name: string;
+export interface MetaData {
+  publication_date: string;
+  version: string;
   size: number;
+  filename: string;
+  url: string;
+  modified: number;
 }
 
 const baseUrl =
   "https://raw.githubusercontent.com/Rubber1Duck/RD_RKI_COVID19_DATA/master/dataStore/";
 
-async function getMetaData(): Promise<MetaData> {
+export async function getMetaData(): Promise<MetaData> {
   let metaData: MetaData;
   // check if redis entry for meta data exists, if yes use it
   const redisEntryMeta = await GetRedisEntry(redisClientBas, "meta");
@@ -512,7 +514,11 @@ async function getMetaData(): Promise<MetaData> {
       0
     );
     // calculate the seconds from now to validTo
-    const validForSec = Math.ceil((validToMs - new Date().getTime()) / 1000);
+    // if Math.ceil((validToMs - new Date().getTime()) / 1000) < 0 then set validForSec to 3600 () (one more hour to wait for Updates)
+    const validForSec =
+      Math.ceil((validToMs - new Date().getTime()) / 1000) > 0
+        ? Math.ceil((validToMs - new Date().getTime()) / 1000)
+        : 3600;
     // create redis Entry for metaData
     await AddRedisEntry(redisClientBas, "meta", metaRedis, validForSec, "json");
   } else {


### PR DESCRIPTION
Till now the self calculated frozen-incidence values are stored in github in single daily files for districts and states each.
The RKI dont continue update the frozen-incidence data in their Excelsheets from 2023-04-17 on. This led to more and more data requests, so I decided to merge the individual days into one file so that only one data request is necessary (each for districts and states). I already described that in the last PR. This is now the transition to the merged data.

I also optimized the cache strategie .............. hopefully no more manualy purgeCache actions are necessary.

After merging this PR the redis and cloudflare cache must be purged!!!