### PR TITLE
Cache all Gh API requests so requests are limited to 5 times a hour

### DIFF
--- a/src/data-requests/hospitalization.ts
+++ b/src/data-requests/hospitalization.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { ResponseData } from "./response-data";
 import parse from "csv-parse";
 import { ApiData } from "./r-value";
+import { GetApiCommit } from "../utils";
 
 enum AgeGroup {
   "00-04" = "A00-A04",
@@ -290,15 +291,12 @@ export async function getHospitalizationData(): Promise<
       });
     }
   );
-
+  const apiUrl = new URL("https://api.github.com/repos/robert-koch-institut/COVID-19-Hospitalisierungen_in_Deutschland/commits/master");
   const [hospitalizationData, lastUpdate] = await Promise.all([
     hospitalizationDataPromise,
-    axios
-      .get(
-        "https://api.github.com/repos/robert-koch-institut/COVID-19-Hospitalisierungen_in_Deutschland/commits/master"
-      )
+    GetApiCommit(apiUrl.href, apiUrl.pathname)
       .then((response) => {
-        const apiData: ApiData = response.data;
+        const apiData: ApiData = response;
         return new Date(apiData.commit.author.date);
       }),
   ]);

--- a/src/data-requests/hospitalization.ts
+++ b/src/data-requests/hospitalization.ts
@@ -291,14 +291,15 @@ export async function getHospitalizationData(): Promise<
       });
     }
   );
-  const apiUrl = new URL("https://api.github.com/repos/robert-koch-institut/COVID-19-Hospitalisierungen_in_Deutschland/commits/master");
+  const apiUrl = new URL(
+    "https://api.github.com/repos/robert-koch-institut/COVID-19-Hospitalisierungen_in_Deutschland/commits/master"
+  );
   const [hospitalizationData, lastUpdate] = await Promise.all([
     hospitalizationDataPromise,
-    GetApiCommit(apiUrl.href, apiUrl.pathname)
-      .then((response) => {
-        const apiData: ApiData = response;
-        return new Date(apiData.commit.author.date);
-      }),
+    GetApiCommit(apiUrl.href, apiUrl.pathname).then((response) => {
+      const apiData: ApiData = response;
+      return new Date(apiData.commit.author.date);
+    }),
   ]);
 
   return {

--- a/src/data-requests/r-value.ts
+++ b/src/data-requests/r-value.ts
@@ -118,8 +118,12 @@ function sumInterval(
   return sum;
 }
 
-const rValueDataUrl = new URL("https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/main/Nowcast_R_aktuell.csv");
-const rValueApiUrl = new URL("https://api.github.com/repos/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/commits/main");
+const rValueDataUrl = new URL(
+  "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/main/Nowcast_R_aktuell.csv"
+);
+const rValueApiUrl = new URL(
+  "https://api.github.com/repos/robert-koch-institut/SARS-CoV-2-Nowcasting_und_-R-Schaetzung/commits/main"
+);
 
 function parseRValue(data: ArrayBuffer): {
   rValue4Days: {

--- a/src/data-requests/vaccination.ts
+++ b/src/data-requests/vaccination.ts
@@ -590,23 +590,37 @@ export async function getVaccinationCoverage(): Promise<
       });
     }
   );
-  const apiUrlCommitsMain = new URL(`https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/commits/main`);
-  const apiResponse: { lastUpdate: Date; sha: string } = await GetApiCommit(apiUrlCommitsMain.href, apiUrlCommitsMain.pathname)
-    .then((apiData) => {
-      const lastUpdate = new Date(apiData.commit.author.date);
-      const sha = apiData.sha;
-      return { lastUpdate, sha };
-    });
+  const apiUrlCommitsMain = new URL(
+    `https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/commits/main`
+  );
+  const apiResponse: { lastUpdate: Date; sha: string } = await GetApiCommit(
+    apiUrlCommitsMain.href,
+    apiUrlCommitsMain.pathname
+  ).then((apiData) => {
+    const lastUpdate = new Date(apiData.commit.author.date);
+    const sha = apiData.sha;
+    return { lastUpdate, sha };
+  });
   const lastUpdate = apiResponse.lastUpdate;
   const sha = apiResponse.sha;
 
   // finde den letzten Datansatz bevor dem aktuellen
-  const apiUrlTreesSha = new URL(`https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/git/trees/${sha}`);
-  const filesResponse = await GetApiTrees(apiUrlTreesSha.href,apiUrlTreesSha.pathname);
+  const apiUrlTreesSha = new URL(
+    `https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/git/trees/${sha}`
+  );
+  const filesResponse = await GetApiTrees(
+    apiUrlTreesSha.href,
+    apiUrlTreesSha.pathname
+  );
   const baseFiles = filesResponse.tree;
   const archiveSha = baseFiles.find((entry) => entry.path == "Archiv").sha;
-  const apiUrlTreesArchivSha = new URL(`https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/git/trees/${archiveSha}`);
-  const archiveResponse = await GetApiTrees(apiUrlTreesArchivSha.href, apiUrlTreesArchivSha.pathname);
+  const apiUrlTreesArchivSha = new URL(
+    `https://api.github.com/repos/robert-koch-institut/COVID-19-Impfungen_in_Deutschland/git/trees/${archiveSha}`
+  );
+  const archiveResponse = await GetApiTrees(
+    apiUrlTreesArchivSha.href,
+    apiUrlTreesArchivSha.pathname
+  );
   const archiveFile = archiveResponse.tree
     .filter((entry) => entry.path.includes("Bundeslaender"))
     .sort((a, b) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import zlib from "zlib";
 import { redisClientBas } from "./server";
+import { ApiData } from "./data-requests/r-value";
 
 export function getStateAbbreviationById(id: number): string | null {
   switch (id) {
@@ -960,4 +961,78 @@ export async function getAgeGroupDistrictsJson(
     );
   }
   return ageGroupDistrictsJson;
+}
+
+export async function GetApiCommit(url: string, key: string): Promise<ApiData> {
+  let apiData: ApiData
+  const apiDataRedis = await GetRedisEntry(redisClientBas, key,);
+  if (apiDataRedis.length == 1) {
+    apiData = JSON.parse(
+      apiDataRedis[0].body,
+      dateReviver
+    );
+  } else {
+  // if redisEntry for cases not exists get data from github und store data to redis
+    const response = await axios.get(url);
+    const rData = response.data;
+    if (rData.error) {
+      throw new RKIError(rData.error, response.config.url);
+    }
+    // prepare data for redis
+    apiData = rData;
+    const apiDataRedis = JSON.stringify(apiData);
+    // create redis Entry for metaData
+    await AddRedisEntry(
+      redisClientBas,
+      key,
+      apiDataRedis,
+      720,
+      "json"
+    );
+  }
+  return apiData
+}
+
+export interface ApiTreesSha {
+  sha: string;
+  url: string;
+  truncated: boolean;
+  tree: {
+    path: string;
+    mode: string;
+    type: string;
+    sha: string;
+    size: number;
+    url: string;
+  }[];
+}
+
+export async function GetApiTrees(url: string, key: string): Promise<ApiTreesSha> {
+  let apiData: ApiTreesSha
+  const apiDataRedis = await GetRedisEntry(redisClientBas, key,);
+  if (apiDataRedis.length == 1) {
+    apiData = JSON.parse(
+      apiDataRedis[0].body,
+      dateReviver
+    );
+  } else {
+  // if redisEntry for cases not exists get data from github und store data to redis
+    const response = await axios.get(url);
+    const rData = response.data;
+    if (rData.error) {
+      throw new RKIError(rData.error, response.config.url);
+    }
+    // prepare data for redis
+    apiData = rData;
+    const apiDataRedis = JSON.stringify(apiData);
+    // create redis Entry for metaData
+    await AddRedisEntry(
+      redisClientBas,
+      key,
+      apiDataRedis,
+      720,
+      "json"
+    );
+  }
+  return apiData
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -964,15 +964,12 @@ export async function getAgeGroupDistrictsJson(
 }
 
 export async function GetApiCommit(url: string, key: string): Promise<ApiData> {
-  let apiData: ApiData
-  const apiDataRedis = await GetRedisEntry(redisClientBas, key,);
+  let apiData: ApiData;
+  const apiDataRedis = await GetRedisEntry(redisClientBas, key);
   if (apiDataRedis.length == 1) {
-    apiData = JSON.parse(
-      apiDataRedis[0].body,
-      dateReviver
-    );
+    apiData = JSON.parse(apiDataRedis[0].body, dateReviver);
   } else {
-  // if redisEntry for cases not exists get data from github und store data to redis
+    // if redisEntry for cases not exists get data from github und store data to redis
     const response = await axios.get(url);
     const rData = response.data;
     if (rData.error) {
@@ -982,15 +979,9 @@ export async function GetApiCommit(url: string, key: string): Promise<ApiData> {
     apiData = rData;
     const apiDataRedis = JSON.stringify(apiData);
     // create redis Entry for metaData
-    await AddRedisEntry(
-      redisClientBas,
-      key,
-      apiDataRedis,
-      720,
-      "json"
-    );
+    await AddRedisEntry(redisClientBas, key, apiDataRedis, 720, "json");
   }
-  return apiData
+  return apiData;
 }
 
 export interface ApiTreesSha {
@@ -1007,16 +998,16 @@ export interface ApiTreesSha {
   }[];
 }
 
-export async function GetApiTrees(url: string, key: string): Promise<ApiTreesSha> {
-  let apiData: ApiTreesSha
-  const apiDataRedis = await GetRedisEntry(redisClientBas, key,);
+export async function GetApiTrees(
+  url: string,
+  key: string
+): Promise<ApiTreesSha> {
+  let apiData: ApiTreesSha;
+  const apiDataRedis = await GetRedisEntry(redisClientBas, key);
   if (apiDataRedis.length == 1) {
-    apiData = JSON.parse(
-      apiDataRedis[0].body,
-      dateReviver
-    );
+    apiData = JSON.parse(apiDataRedis[0].body, dateReviver);
   } else {
-  // if redisEntry for cases not exists get data from github und store data to redis
+    // if redisEntry for cases not exists get data from github und store data to redis
     const response = await axios.get(url);
     const rData = response.data;
     if (rData.error) {
@@ -1026,13 +1017,7 @@ export async function GetApiTrees(url: string, key: string): Promise<ApiTreesSha
     apiData = rData;
     const apiDataRedis = JSON.stringify(apiData);
     // create redis Entry for metaData
-    await AddRedisEntry(
-      redisClientBas,
-      key,
-      apiDataRedis,
-      720,
-      "json"
-    );
+    await AddRedisEntry(redisClientBas, key, apiDataRedis, 720, "json");
   }
-  return apiData
+  return apiData;
 }


### PR DESCRIPTION
Gh API requests are limited to 35 requests a hour. If new data is availible this will causes in issues.
This patch will cache all api requests to redis and limit the api requests to 5 times a hour. all in one there are 7 api requests that must be done. So in worst case 35 requests are done witch will hold the limits!
@marlon360 please approve and merge, thanks 